### PR TITLE
Fix for PDB writer that caused overlap of atom coordinate columns.

### DIFF
--- a/stk/molecular/molecules/molecule.py
+++ b/stk/molecular/molecules/molecule.py
@@ -304,11 +304,12 @@ class Molecule:
             for atoms_group in atoms_dihedral:
                 # Calculate the dihedral angle.
                 dihedral_value = rdMolTransforms.GetDihedralDeg(
-                                    self.mol.GetConformer(conformer),
-                                    atoms_group[0],
-                                    atoms_group[1],
-                                    atoms_group[2],
-                                    atoms_group[3])
+                    self.mol.GetConformer(conformer),
+                    atoms_group[0],
+                    atoms_group[1],
+                    atoms_group[2],
+                    atoms_group[3]
+                )
                 # Check that the dihedral is calculated in the right
                 # direction.
                 if abs(dihedral_value) > 90:
@@ -1275,19 +1276,23 @@ class Molecule:
         atom_counts = {}
         hetatm = 'HETATM'
         alt_loc = ''
-        res_name = 'UNL'
+        res_name = 'UNK'
         chain_id = ''
         res_seq = '1'
         i_code = ''
         occupancy = '1.00'
         temp_factor = '0.00'
+        print(res_name)
         for atom in atoms:
             serial = atom+1
             element = self.atom_symbol(atom)
             atom_counts[element] = atom_counts.get(element, 0) + 1
             name = f'{element}{atom_counts[element]}'
-            # Make sure the coords are no more than 8 columns wide each.
-            x, y, z = (f'{i}'[:8] for i in self.atom_coords(atom, conformer))
+            # Make sure the coords are no more than 8 columns wide
+            # each.
+            x, y, z = (
+                f'{i}'[:8] for i in self.atom_coords(atom, conformer)
+            )
             charge = self.mol.GetAtomWithIdx(atom).GetFormalCharge()
             lines.append(
                 f'{hetatm:<6}{serial:>5} {name:<4}'

--- a/stk/molecular/molecules/molecule.py
+++ b/stk/molecular/molecules/molecule.py
@@ -1282,23 +1282,22 @@ class Molecule:
         i_code = ''
         occupancy = '1.00'
         temp_factor = '0.00'
-        print(res_name)
         for atom in atoms:
             serial = atom+1
             element = self.atom_symbol(atom)
             atom_counts[element] = atom_counts.get(element, 0) + 1
             name = f'{element}{atom_counts[element]}'
             # Make sure the coords are no more than 8 columns wide
-            # each.
+            # each. Round numbers to 7 digits to avoid overlap.
             x, y, z = (
-                f'{i}'[:8] for i in self.atom_coords(atom, conformer)
+                f'{i}'[:7] for i in self.atom_coords(atom, conformer)
             )
             charge = self.mol.GetAtomWithIdx(atom).GetFormalCharge()
             lines.append(
                 f'{hetatm:<6}{serial:>5} {name:<4}'
                 f'{alt_loc:<1}{res_name:<3} {chain_id:<1}'
                 f'{res_seq:>4}{i_code:<1}   '
-                f'{x:>8}{y:>8}{z:>8}'
+                f' {x:>7} {y:>7} {z:>7}'
                 f'{occupancy:>6}{temp_factor:>6}          '
                 f'{element:>2}{charge:>2}\n'
             )

--- a/tests/test_molecule.py
+++ b/tests/test_molecule.py
@@ -363,7 +363,7 @@ def test_pdb_write(cycle_su):
     assert np.allclose(
         a=cycle_su.position_matrix(),
         b=cycle.position_matrix(),
-        atol=1e-5
+        atol=1e-3
     )
 
     # Make sure the connectivity is the same.
@@ -387,7 +387,7 @@ def test_pdb_write(cycle_su):
     assert np.allclose(
         a=cycle_su.position_matrix()[:, atoms],
         b=cycle.position_matrix(),
-        atol=1e-5
+        atol=1e-3
     )
 
     # Make sure the bonds which need to exist exist.
@@ -415,5 +415,5 @@ def test_pdb_write(cycle_su):
     assert np.allclose(
         a=bonds1,
         b=bonds2,
-        atol=1e-5
+        atol=1e-3
     )


### PR DESCRIPTION
Minor changes to _write_pdb function in molecule.py to conform with the PDB column rules