### PR TITLE
Remove all shell access in xTB functions.

### DIFF
--- a/stk/calculators/energy/energy_calculators.py
+++ b/stk/calculators/energy/energy_calculators.py
@@ -793,9 +793,8 @@ class XTBEnergy(EnergyCalculator):
                 stdin=sp.PIPE,
                 stdout=f,
                 stderr=sp.PIPE,
-                # Uses the shell if unlimited_memory is True to run
-                # multiple commands in one subprocess.
-                shell=self.unlimited_memory
+                # Shell is required to run complex arguments.
+                shell=True
             )
 
     def energy(self, mol, conformer=-1):

--- a/stk/calculators/optimization/optimizers.py
+++ b/stk/calculators/optimization/optimizers.py
@@ -1078,9 +1078,8 @@ class XTB(Optimizer):
                 stdin=sp.PIPE,
                 stdout=f,
                 stderr=sp.PIPE,
-                # Uses the shell if unlimited_memory is True to run
-                # multiple commands in one subprocess.
-                shell=self.unlimited_memory
+                # Shell is required to run complex arguments.
+                shell=True
             )
 
     def _run_optimizations(self, mol, conformer):

--- a/tests/test_xtb.py
+++ b/tests/test_xtb.py
@@ -26,8 +26,7 @@ def test_xtb_negfreq(tmp_polymer, xtb_path):
     out_dir = 'gfnxtb_NF_energy'
     energy = stk.XTBEnergy(
         xtb_path=xtb_path,
-        output_dir=join(odir, out_dir),
-        unlimited_memory=True
+        output_dir=join(odir, out_dir)
     )
 
     # Calculate the initial energy.
@@ -39,7 +38,6 @@ def test_xtb_negfreq(tmp_polymer, xtb_path):
     opt_lowtol = stk.XTB(
         xtb_path=xtb_path,
         output_dir=join(odir, out_dir),
-        unlimited_memory=True,
         opt_level='crude',
         max_runs=1,
         calculate_hessian=True
@@ -63,7 +61,6 @@ def test_xtb_negfreq(tmp_polymer, xtb_path):
     opt_hightol = stk.XTB(
         xtb_path=xtb_path,
         output_dir=join(odir, out_dir),
-        unlimited_memory=True,
         opt_level='extreme',
         max_runs=1,
         calculate_hessian=True
@@ -98,8 +95,7 @@ def test_xtb_solvent_charge_uhf(tmp_polymer, xtb_path):
     out_dir = 'gfnxtb_energy'
     energy = stk.XTBEnergy(
         xtb_path=xtb_path,
-        output_dir=join(odir, out_dir),
-        unlimited_memory=True
+        output_dir=join(odir, out_dir)
     )
     init_energy = energy.energy(tmp_polymer)
 
@@ -110,7 +106,6 @@ def test_xtb_solvent_charge_uhf(tmp_polymer, xtb_path):
     solvent = stk.XTBEnergy(
         xtb_path=xtb_path,
         output_dir=join(odir, out_dir),
-        unlimited_memory=True,
         solvent='h2o'
     )
     solv_energy = solvent.energy(tmp_polymer)
@@ -123,7 +118,6 @@ def test_xtb_solvent_charge_uhf(tmp_polymer, xtb_path):
     charge = stk.XTBEnergy(
         xtb_path=xtb_path,
         output_dir=join(odir, out_dir),
-        unlimited_memory=True,
         charge=-1
     )
     charge_energy = charge.energy(tmp_polymer)
@@ -136,7 +130,6 @@ def test_xtb_solvent_charge_uhf(tmp_polymer, xtb_path):
     multi = stk.XTBEnergy(
         xtb_path=xtb_path,
         output_dir=join(odir, out_dir),
-        unlimited_memory=True,
         num_unpaired_electrons=2
     )
     multi_energy = multi.energy(tmp_polymer)
@@ -158,7 +151,6 @@ def test_xtb_properties(tmp_polymer, xtb_path):
     gfnxtb = stk.XTB(
         xtb_path,
         output_dir=join(odir, 'gfnxtb_opt'),
-        unlimited_memory=False,
         opt_level='extreme',
         max_runs=1,
         calculate_hessian=False,
@@ -168,7 +160,6 @@ def test_xtb_properties(tmp_polymer, xtb_path):
     xtb = stk.XTBEnergy(
         xtb_path=xtb_path,
         output_dir=join(odir, 'gfnxtb_ey'),
-        unlimited_memory=False,
         calculate_free_energy=True
     )
     total_energy = xtb.energy(tmp_polymer)

--- a/tests/test_xtb.py
+++ b/tests/test_xtb.py
@@ -158,7 +158,7 @@ def test_xtb_properties(tmp_polymer, xtb_path):
     gfnxtb = stk.XTB(
         xtb_path,
         output_dir=join(odir, 'gfnxtb_opt'),
-        unlimited_memory=True,
+        unlimited_memory=False,
         opt_level='extreme',
         max_runs=1,
         calculate_hessian=False,
@@ -168,7 +168,7 @@ def test_xtb_properties(tmp_polymer, xtb_path):
     xtb = stk.XTBEnergy(
         xtb_path=xtb_path,
         output_dir=join(odir, 'gfnxtb_ey'),
-        unlimited_memory=True,
+        unlimited_memory=False,
         calculate_free_energy=True
     )
     total_energy = xtb.energy(tmp_polymer)


### PR DESCRIPTION
Trying to remove security flaw in the use of shell=True in a subprocess n 
Fixes #47 .

For now, complete removal of the unlimited memory flag is best as the subprocess command is not safe from user input.

The XTB manual should explain to the users how to use unlimited memory if they have memory issues.
