### PR TITLE
handle is_datives in reactions and tests.

### DIFF
--- a/src/stk/molecular/reactions/reactions/one_one_reaction.py
+++ b/src/stk/molecular/reactions/reactions/one_one_reaction.py
@@ -23,6 +23,7 @@ class OneOneReaction(Reaction):
         functional_group2,
         bond_order,
         periodicity,
+        is_dative,
     ):
         """
         Initialize a :class:`.OneOneReaction` instance.
@@ -41,12 +42,16 @@ class OneOneReaction(Reaction):
         periodicity : :class:`tuple` of :class:`int`
             The periodicity of the bond created by the reaction.
 
+        is_dative : :class:`bool`
+            ``True`` if created bond is dative.
+
         """
 
         self._functional_group1 = functional_group1
         self._functional_group2 = functional_group2
         self._bond_order = bond_order
         self._periodicity = periodicity
+        self._is_dative = is_dative
 
     def _get_new_atoms(self):
         return
@@ -60,6 +65,7 @@ class OneOneReaction(Reaction):
             atom2=bonder2,
             order=self._bond_order,
             periodicity=self._periodicity,
+            is_dative=self._is_dative,
         )
 
     def _get_deleted_atoms(self):

--- a/src/stk/molecular/reactions/reactions/one_two_reaction.py
+++ b/src/stk/molecular/reactions/reactions/one_two_reaction.py
@@ -26,6 +26,7 @@ class OneTwoReaction(Reaction):
         functional_group2,
         bond_order,
         periodicity,
+        is_dative,
     ):
         """
         Initialize a :class:`.OneTwoReaction` instance.
@@ -44,12 +45,16 @@ class OneTwoReaction(Reaction):
         periodicity : :class:`tuple` of :class:`int`
             The periodicity of the bond created by the reaction.
 
+        is_dative : :class:`bool`
+            ``True`` if created bond is dative.
+
         """
 
         self._functional_group1 = functional_group1
         self._functional_group2 = functional_group2
         self._bond_order = bond_order
         self._periodicity = periodicity
+        self._is_dative = is_dative
 
     def _get_new_atoms(self):
         return
@@ -64,6 +69,7 @@ class OneTwoReaction(Reaction):
                 atom2=bonder2,
                 order=self._bond_order,
                 periodicity=self._periodicity,
+                is_dative=self._is_dative
             )
 
     def _get_deleted_atoms(self):

--- a/src/stk/molecular/reactions/reactions/two_two_reaction.py
+++ b/src/stk/molecular/reactions/reactions/two_two_reaction.py
@@ -28,6 +28,7 @@ class TwoTwoReaction(Reaction):
         functional_group2,
         bond_order,
         periodicity,
+        is_dative,
     ):
         """
         Initialize a :class:`.TwoTwoReaction` instance.
@@ -49,6 +50,9 @@ class TwoTwoReaction(Reaction):
         periodicity : :class:`tuple` of :class:`int`
             The periodicity of the bonds created by the reaction.
 
+        is_dative : :class:`bool`
+            ``True`` if created bond is dative.
+
         """
 
         self._position_matrix = (
@@ -58,6 +62,7 @@ class TwoTwoReaction(Reaction):
         self._functional_group2 = functional_group2
         self._bond_order = bond_order
         self._periodicity = periodicity
+        self._is_dative = is_dative
 
     def _get_new_atoms(self):
         return
@@ -70,6 +75,7 @@ class TwoTwoReaction(Reaction):
                 atom2=bonder2,
                 order=self._bond_order,
                 periodicity=self._periodicity,
+                is_dative=self._is_dative,
             )
 
     def _get_bonder_pairs(self):

--- a/tests/molecular/reactions/reaction/conftest.py
+++ b/tests/molecular/reactions/reaction/conftest.py
@@ -228,6 +228,18 @@ def bond_order(request):
 
 
 @pytest.fixture(
+    params=(True, False),
+)
+def is_dative(request):
+    """
+    Whether or not a bond made by a reaction is dative.
+
+    """
+
+    return request.param
+
+
+@pytest.fixture(
     params=(
         (0, 0, 0),
         (0, -1, 0),

--- a/tests/molecular/reactions/reaction/fixtures/one_one_reaction.py
+++ b/tests/molecular/reactions/reaction/fixtures/one_one_reaction.py
@@ -21,6 +21,7 @@ def one_one_reaction(
     functional_group2,
     bond_order,
     periodicity,
+    is_dative,
 ):
     """
     A :class:`.CaseData` instance.
@@ -33,6 +34,7 @@ def one_one_reaction(
             functional_group2=functional_group2,
             bond_order=bond_order,
             periodicity=periodicity,
+            is_dative=is_dative,
         ),
         new_atoms=(),
         new_bonds=(
@@ -41,6 +43,7 @@ def one_one_reaction(
                 functional_group2=functional_group2,
                 bond_order=bond_order,
                 periodicity=periodicity,
+                is_dative=is_dative,
             ),
         ),
         deleted_atoms=tuple(it.chain(
@@ -55,10 +58,12 @@ def get_bond(
     functional_group2,
     bond_order,
     periodicity,
+    is_dative,
 ):
     return stk.Bond(
         atom1=next(functional_group1.get_bonders()),
         atom2=next(functional_group2.get_bonders()),
         order=bond_order,
         periodicity=periodicity,
+        is_dative=is_dative,
     )

--- a/tests/molecular/reactions/reaction/fixtures/one_two_reaction.py
+++ b/tests/molecular/reactions/reaction/fixtures/one_two_reaction.py
@@ -11,6 +11,7 @@ def one_two_reaction(
     functional_group2,
     bond_order,
     periodicity,
+    is_dative,
 ):
     """
     A :class:`.CaseData` instance.
@@ -23,6 +24,7 @@ def one_two_reaction(
             functional_group2=functional_group2,
             bond_order=bond_order,
             periodicity=periodicity,
+            is_dative=is_dative,
         ),
         new_atoms=(),
         new_bonds=tuple(
@@ -31,6 +33,7 @@ def one_two_reaction(
                 functional_group2=functional_group2,
                 bond_order=bond_order,
                 periodicity=periodicity,
+                is_dative=is_dative,
             ),
         ),
         deleted_atoms=tuple(it.chain(
@@ -45,6 +48,7 @@ def get_bonds(
     functional_group2,
     bond_order,
     periodicity,
+    is_dative,
 ):
     bonders1 = functional_group1.get_bonders()
     bonders2 = functional_group2.get_bonders()
@@ -54,4 +58,5 @@ def get_bonds(
             atom2=bonder2,
             order=bond_order,
             periodicity=periodicity,
+            is_dative=is_dative,
         )

--- a/tests/molecular/reactions/reaction/fixtures/two_two_reaction.py
+++ b/tests/molecular/reactions/reaction/fixtures/two_two_reaction.py
@@ -25,6 +25,7 @@ def two_two_reaction(
     functional_group2_2,
     bond_order,
     periodicity,
+    is_dative,
 ):
     """
     A :class:`.CaseData` instance.
@@ -41,6 +42,7 @@ def two_two_reaction(
             functional_group2=functional_group2,
             bond_order=bond_order,
             periodicity=periodicity,
+            is_dative=is_dative,
         ),
         new_atoms=(),
         new_bonds=tuple(
@@ -49,6 +51,7 @@ def two_two_reaction(
                 functional_group2=functional_group2,
                 bond_order=bond_order,
                 periodicity=periodicity,
+                is_dative=is_dative,
             ),
         ),
         deleted_atoms=tuple(it.chain(
@@ -63,6 +66,7 @@ def get_bonds(
     functional_group2,
     bond_order,
     periodicity,
+    is_dative,
 ):
     b1, b2 = functional_group1.get_bonders()
     b3, b4 = functional_group2.get_bonders()
@@ -71,6 +75,7 @@ def get_bonds(
         atom2=b3,
         order=bond_order,
         periodicity=periodicity,
+        is_dative=is_dative,
     )
 
     yield stk.Bond(
@@ -78,6 +83,7 @@ def get_bonds(
         atom2=b4,
         order=bond_order,
         periodicity=periodicity,
+        is_dative=is_dative,
     )
 
 

--- a/tests/molecular/reactions/reaction/utilities.py
+++ b/tests/molecular/reactions/reaction/utilities.py
@@ -22,5 +22,6 @@ def is_equivalent_bond(bond1, bond2):
     assert bond1.__class__ is bond2.__class__
     assert bond1.get_order() == bond2.get_order()
     assert bond1.get_periodicity() == bond2.get_periodicity()
+    assert bond1.is_dative() == bond2.is_dative()
     is_equivalent_atom(bond1.get_atom1(), bond2.get_atom1())
     is_equivalent_atom(bond1.get_atom2(), bond2.get_atom2())

--- a/tests/molecular/reactions/reaction_factory/conftest.py
+++ b/tests/molecular/reactions/reaction_factory/conftest.py
@@ -225,6 +225,18 @@ def bond_order(request):
 
 
 @pytest.fixture(
+    params=(True, False),
+)
+def is_dative(request):
+    """
+    Whether or not a bond created by a :class:`.Reaction` is dative.
+
+    """
+
+    return request.param
+
+
+@pytest.fixture(
     params=(
         lazy_fixture('one_one_reaction'),
         lazy_fixture('one_two_reaction'),

--- a/tests/molecular/reactions/reaction_factory/fixtures/one_one_reaction.py
+++ b/tests/molecular/reactions/reaction_factory/fixtures/one_one_reaction.py
@@ -23,8 +23,13 @@ def one_one_reaction(
     functional_group1,
     functional_group1_2,
     bond_order,
+    is_dative,
 ):
     bond_order_key = frozenset({
+        type(functional_group1),
+        type(functional_group1_2),
+    })
+    is_dative_key = frozenset({
         type(functional_group1),
         type(functional_group1_2),
     })
@@ -33,6 +38,9 @@ def one_one_reaction(
         factory=stk.GenericReactionFactory(
             bond_orders={
                 bond_order_key: bond_order,
+            },
+            is_datives={
+                is_dative_key: is_dative,
             },
         ),
         construction_state=MockConstructionState(
@@ -54,6 +62,7 @@ def one_one_reaction(
                 functional_group2=functional_group1_2,
                 order=bond_order,
                 periodicity=periodicity,
+                is_dative=is_dative,
             ),
             deleted_atoms=it.chain(
                 functional_group1.get_deleters(),
@@ -68,10 +77,12 @@ def get_new_bonds(
     functional_group2,
     order,
     periodicity,
+    is_dative
 ):
     yield stk.Bond(
         atom1=next(functional_group1.get_bonders()),
         atom2=next(functional_group2.get_bonders()),
         order=order,
         periodicity=periodicity,
+        is_dative=is_dative,
     )

--- a/tests/molecular/reactions/reaction_factory/fixtures/one_two_reaction.py
+++ b/tests/molecular/reactions/reaction_factory/fixtures/one_two_reaction.py
@@ -13,8 +13,13 @@ def one_two_reaction(
     functional_group1,
     functional_group2,
     bond_order,
+    is_dative,
 ):
     bond_order_key = frozenset({
+        type(functional_group1),
+        type(functional_group2),
+    })
+    is_dative_key = frozenset({
         type(functional_group1),
         type(functional_group2),
     })
@@ -23,6 +28,9 @@ def one_two_reaction(
         factory=stk.GenericReactionFactory(
             bond_orders={
                 bond_order_key: bond_order,
+            },
+            is_datives={
+                is_dative_key: is_dative,
             },
         ),
         construction_state=MockConstructionState(
@@ -44,6 +52,7 @@ def one_two_reaction(
                 functional_group2=functional_group2,
                 order=bond_order,
                 periodicity=periodicity,
+                is_dative=is_dative,
             ),
             deleted_atoms=it.chain(
                 functional_group1.get_deleters(),
@@ -58,6 +67,7 @@ def get_new_bonds(
     functional_group2,
     order,
     periodicity,
+    is_dative,
 ):
     fg1_bonder = next(functional_group1.get_bonders())
     fg2_bonders = functional_group2.get_bonders()
@@ -66,10 +76,12 @@ def get_new_bonds(
         atom2=next(fg2_bonders),
         order=order,
         periodicity=periodicity,
+        is_dative=is_dative,
     )
     yield stk.Bond(
         atom1=fg1_bonder,
         atom2=next(fg2_bonders),
         order=order,
         periodicity=periodicity,
+        is_dative=is_dative,
     )

--- a/tests/molecular/reactions/reaction_factory/fixtures/two_two_reaction.py
+++ b/tests/molecular/reactions/reaction_factory/fixtures/two_two_reaction.py
@@ -24,8 +24,13 @@ def two_two_reaction(
     functional_group2,
     functional_group2_2,
     bond_order,
+    is_dative,
 ):
     bond_order_key = frozenset({
+        type(functional_group2),
+        type(functional_group2_2),
+    })
+    is_dative_key = frozenset({
         type(functional_group2),
         type(functional_group2_2),
     })
@@ -38,6 +43,9 @@ def two_two_reaction(
         factory=stk.GenericReactionFactory(
             bond_orders={
                 bond_order_key: bond_order,
+            },
+            is_datives={
+                is_dative_key: is_dative,
             },
         ),
         construction_state=MockConstructionState(
@@ -60,6 +68,7 @@ def two_two_reaction(
                 functional_group2=functional_group2_2,
                 order=bond_order,
                 periodicity=periodicity,
+                is_dative=is_dative,
             ),
             deleted_atoms=it.chain(
                 functional_group2.get_deleters(),
@@ -74,6 +83,7 @@ def get_new_bonds(
     functional_group2,
     order,
     periodicity,
+    is_dative,
 ):
     bonder1, bonder2 = functional_group1.get_bonders()
     bonder3, bonder4 = functional_group2.get_bonders()
@@ -82,12 +92,14 @@ def get_new_bonds(
         atom2=bonder3,
         order=order,
         periodicity=periodicity,
+        is_dative=is_dative,
     )
     yield stk.Bond(
         atom1=bonder2,
         atom2=bonder4,
         order=order,
         periodicity=periodicity,
+        is_dative=is_dative,
     )
 
 

--- a/tests/molecular/reactions/reaction_factory/test_get_reaction.py
+++ b/tests/molecular/reactions/reaction_factory/test_get_reaction.py
@@ -118,3 +118,4 @@ def is_same_bond(bond1, bond2):
         )
     )
     assert bond1.get_periodicity() == bond2.get_periodicity()
+    assert bond1.is_dative() == bond2.is_dative()


### PR DESCRIPTION
This is implementation to handle the presence of dative bonds in reactions that are not currently defined (functional groups that produce dative bonds will be defined when needed)