### PR TITLE
Caching fix

### DIFF
--- a/src/stk/databases/mongo_db/constructed_molecule.py
+++ b/src/stk/databases/mongo_db/constructed_molecule.py
@@ -301,15 +301,29 @@ class ConstructedMoleculeMongoDb(ConstructedMoleculeDatabase):
         return self._put(HashableDict(json))
 
     def _put(self, json):
-        self._position_matrices.insert_one(json['matrix'])
-        self._molecules.insert_one(json['molecule'])
+        # insert_one() corrupts the state of the dict it is passed
+        # as an argument (it adds various items to it).
+        # Using insert_one(json['molecule']) would mean that the json
+        # in the lru_cache is modified with some extra items added by
+        # insert_one(). This means that the next time _put() is used
+        # with a clean json, it will not match the one in the cache,
+        # because the one in the cache has the extra items added by
+        # insert_one(). To prevent this use
+        # insert_one(dict(json['molecule'])), which means that a copy
+        # is modified by insert_one and the json in the cache is
+        # not changed.
+
+        self._position_matrices.insert_one(dict(json['matrix']))
+        self._molecules.insert_one(dict(json['molecule']))
         self._constructed_molecules.insert_one(
-            document=json['constructedMolecule'],
+            document=dict(json['constructedMolecule']),
         )
         for building_block_json in json['buildingBlocks']:
-            self._molecules.insert_one(building_block_json['molecule'])
+            self._molecules.insert_one(
+                document=dict(building_block_json['molecule']),
+            )
             self._position_matrices.insert_one(
-                document=building_block_json['matrix'],
+                document=dict(building_block_json['matrix']),
             )
 
     def get(self, key):

--- a/src/stk/databases/mongo_db/molecule.py
+++ b/src/stk/databases/mongo_db/molecule.py
@@ -263,7 +263,7 @@ class MoleculeMongoDb(MoleculeDatabase):
 
     def _put(self, json):
         # insert_one() corrupts the state of the dict it is passed
-        # as an argument (it adds various keys and values items to it).
+        # as an argument (it adds various items to it).
         # Using insert_one(json['molecule']) would mean that the json
         # in the lru_cache is modified with some extra items added by
         # insert_one(). This means that the next time _put() is used


### PR DESCRIPTION
MongoDb's caching of `_put()` was not working, because `insert_one()` modified the `HashableDict` which was placed in the `lru_cache`. This resulted in the `HashableDict` in the `lru_cache` being different to the a clean `HashableDict` passed to `_put()`.