### PR TITLE
Deprecate ValueMongoDb arguments.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,5 +15,7 @@ install:
     - conda env create -f ./tests/environment.yml
     - conda activate stk_test
 
+services: mongodb
+
 script:
     - pytest

--- a/src/stk/databases/mongo_db/value.py
+++ b/src/stk/databases/mongo_db/value.py
@@ -5,6 +5,7 @@ Value MongoDB
 """
 
 from functools import lru_cache
+import warnings
 
 from stk.molecular import InchiKey
 from .utilities import HashableDict
@@ -73,7 +74,9 @@ class ValueMongoDb(ValueDatabase):
         collection,
         database='stk',
         key_makers=(InchiKey(), ),
-        lru_cache_size=128,
+        lru_cache_size='',
+        put_lru_cache_size=128,
+        get_lru_cache_size=128,
         indices=('InChIKey', ),
     ):
         """
@@ -98,8 +101,25 @@ class ValueMongoDb(ValueDatabase):
             key, they will return the same value from the database.
 
         lru_cache_size : :class:`int`, optional
+            This argument is deprecated and will be removed in any
+            version of :mod:`stk` released on, or after, 01/01/21.
+            Use the `put_lru_cache_size` and `get_lru_cache_size`
+            arguments instead.
+
             A RAM-based least recently used cache is used to avoid
             reading and writing to the database repeatedly. This sets
+            the number of values which fit into the LRU cache. If
+            ``None``, the cache size will be unlimited.
+
+        put_lru_cache_size : :class:`int`, optional
+            A RAM-based least recently used cache is used to avoid
+            writing to the database repeatedly. This sets
+            the number of values which fit into the LRU cache. If
+            ``None``, the cache size will be unlimited.
+
+        get_lru_cache_size : :class:`int`, optional
+            A RAM-based least recently used cache is used to avoid
+            reading from the database repeatedly. This sets
             the number of values which fit into the LRU cache. If
             ``None``, the cache size will be unlimited.
 
@@ -109,10 +129,24 @@ class ValueMongoDb(ValueDatabase):
 
         """
 
+        if lru_cache_size == '':
+            lru_cache_size = 128
+
+        else:
+            warnings.warn(
+                'The lru_cache_size argument is deprecated and will '
+                'be removed in any version of stk released on, or '
+                'after, 01/01/21. Use the put_lru_cache_size and '
+                'get_lru_cache_size arguments instead.',
+                FutureWarning,
+            )
+            put_lru_cache_size = lru_cache_size
+            get_lru_cache_size = lru_cache_size
+
         self._values = mongo_client[database][collection]
         self._key_makers = key_makers
-        self._put = lru_cache(maxsize=lru_cache_size)(self._put)
-        self._get = lru_cache(maxsize=lru_cache_size)(self._get)
+        self._put = lru_cache(maxsize=put_lru_cache_size)(self._put)
+        self._get = lru_cache(maxsize=get_lru_cache_size)(self._get)
 
         index_information = self._values.index_information()
         if 'v_1' not in index_information:

--- a/src/stk/databases/mongo_db/value.py
+++ b/src/stk/databases/mongo_db/value.py
@@ -129,10 +129,7 @@ class ValueMongoDb(ValueDatabase):
 
         """
 
-        if lru_cache_size == '':
-            lru_cache_size = 128
-
-        else:
+        if lru_cache_size != '':
             warnings.warn(
                 'The lru_cache_size argument is deprecated and will '
                 'be removed in any version of stk released on, or '

--- a/tests/databases/value/fixtures/mongo_db.py
+++ b/tests/databases/value/fixtures/mongo_db.py
@@ -1,26 +1,30 @@
 import pytest
 import stk
+import pymongo
 
 from ..case_data import CaseData
-from ...utilities import MockMongoClient
 
 
 @pytest.fixture(
     params=(
         CaseData(
             database=stk.ValueMongoDb(
-                mongo_client=MockMongoClient(),
+                mongo_client=pymongo.MongoClient(),
                 collection='values',
-                lru_cache_size=0,
+                database='_test_database',
+                put_lru_cache_size=0,
+                get_lru_cache_size=0,
             ),
             molecule=stk.BuildingBlock('BrCCBr'),
             value=12,
         ),
         CaseData(
             database=stk.ValueMongoDb(
-                mongo_client=MockMongoClient(),
+                mongo_client=pymongo.MongoClient(),
                 collection='values',
-                lru_cache_size=128,
+                database='_test_database',
+                put_lru_cache_size=128,
+                get_lru_cache_size=128,
             ),
             molecule=stk.BuildingBlock('BrCCBr'),
             value=12,

--- a/tests/databases/value/fixtures/mongo_db.py
+++ b/tests/databases/value/fixtures/mongo_db.py
@@ -11,7 +11,7 @@ from ..case_data import CaseData
             database=stk.ValueMongoDb(
                 mongo_client=pymongo.MongoClient(),
                 collection='values',
-                database='_test_database',
+                database='_stk_test_database_for_testing',
                 put_lru_cache_size=0,
                 get_lru_cache_size=0,
             ),
@@ -22,7 +22,7 @@ from ..case_data import CaseData
             database=stk.ValueMongoDb(
                 mongo_client=pymongo.MongoClient(),
                 collection='values',
-                database='_test_database',
+                database='_stk_test_database_for_testing',
                 put_lru_cache_size=128,
                 get_lru_cache_size=128,
             ),

--- a/tests/environment.yml
+++ b/tests/environment.yml
@@ -7,9 +7,9 @@ dependencies:
   - attrs=19.3.0=py_0
   - blas=1.0=mkl
   - bzip2=1.0.8=h7b6447c_0
-  - ca-certificates=2020.1.1=0
+  - ca-certificates=2020.6.24=0
   - cairo=1.14.12=h8948797_3
-  - certifi=2019.11.28=py37_0
+  - certifi=2020.6.20=py37_0
   - cycler=0.10.0=py37_0
   - dbus=1.13.12=h746ee38_0
   - expat=2.2.6=he6710b0_0
@@ -46,7 +46,7 @@ dependencies:
   - numpy=1.18.1=py37h4f9e942_0
   - numpy-base=1.18.1=py37hde5b4d6_1
   - olefile=0.46=py37_0
-  - openssl=1.1.1d=h7b6447c_4
+  - openssl=1.1.1g=h7b6447c_0
   - packaging=20.3=py_0
   - pandas=1.0.1=py37h0573a6f_0
   - pcre=8.43=he6710b0_0
@@ -56,6 +56,7 @@ dependencies:
   - pluggy=0.13.1=py37_0
   - py=1.8.1=py_0
   - py-boost=1.67.0=py37h04863e7_4
+  - pymongo=3.9.0=py37he6710b0_0
   - pyparsing=2.4.6=py_0
   - pyqt=5.9.2=py37h05f1152_2
   - pytest=5.3.5=py37_0


### PR DESCRIPTION
This PR replaces the single `lru_cache_size` argument with two separate `cach_size` arguments. This has the benefit of allowing the user to toggle each cache individually. For example, you might want to allow caching for the `put` method, while preventing caching for the `get` method. You might want to prevent caching in the `get` method exclusively in cases where you are adding the same molecule to the database, but in each case it has a different position matrix. In such a situation, the `get` method would not reflect the updates to the database if caching is turned on.

This PR also makes the tests use an actual MongoDb for testing - because it is easier to test than using a Mock database.
