### PR TITLE
Not treating Inchi warnings as errors.

### DIFF
--- a/src/stk/molecular/key_makers/utilities.py
+++ b/src/stk/molecular/key_makers/utilities.py
@@ -15,9 +15,17 @@ def get_inchi(molecule):
     :class:`str`
         The InChI.
 
+    Raises
+    ------
+    :class:`ValueError`
+        If the InChI of `molecule` cannot be generated.
+
     """
 
-    return rdkit.MolToInchi(molecule.to_rdkit_mol())
+    inchi = rdkit.MolToInchi(molecule.to_rdkit_mol())
+    if inchi:
+        return inchi
+    raise ValueError('The InChI of {molecule} was empty.')
 
 
 def get_inchi_key(molecule):

--- a/src/stk/molecular/key_makers/utilities.py
+++ b/src/stk/molecular/key_makers/utilities.py
@@ -17,10 +17,7 @@ def get_inchi(molecule):
 
     """
 
-    return rdkit.MolToInchi(
-        mol=molecule.to_rdkit_mol(),
-        treatWarningAsError=True,
-    )
+    return rdkit.MolToInchi(molecule.to_rdkit_mol())
 
 
 def get_inchi_key(molecule):


### PR DESCRIPTION
Treating warnings as errors led to some valid molecules causing
errors because their stereochemistry could not be assigned.
See #213 on GitHub.