### PR TITLE
Add MutationPreconditionException

### DIFF
--- a/src/stk/ea/mutation/__init__.py
+++ b/src/stk/ea/mutation/__init__.py
@@ -1,2 +1,3 @@
 from .mutators import *  # noqa
 from .records import *  # noqa
+from .mutation_precondition_violation import *  # noqa

--- a/src/stk/ea/mutation/mutation_precondition_violation.py
+++ b/src/stk/ea/mutation/mutation_precondition_violation.py
@@ -1,0 +1,30 @@
+class MutationPreconditionViolation(Exception):
+    """
+    Raised when a mutation fails due to a precondition violation.
+
+    A precondition violation occurs when a molecule cannot undergo
+    mutation, because it does not satisfy the necessary conditions
+    for that mutation to take place. For example, if you try to
+    mutate the hydrogen atoms of a molecule with no hydrogen atoms,
+    that could be treated as a precondition violation. Note that
+    in this example, it would also be reasonable to just do nothing,
+    and return the unmutated molecule as its own mutant. It is up to
+    the implementor of the mutation algorithm to decide what makes the
+    most sense.
+
+    Note that because an implementation of a
+    :class:`.EvolutionaryAlgorithm` might not remove duplicates of a
+    molecule in the population, returning a molecule as its own mutant
+    may be undesirable, because it could lead to it being
+    overrepresented in the population. Raising
+    :class:`MutationPreconditionViolation` could be an effective
+    way of avoiding such a pitfall.
+
+    However, the default implementation of the
+    :class:`.EvolutionaryAlgorithm` does actually remove duplicate
+    molecules from the population, so you would avoid such an pitfall
+    regardless of the approach taken.
+
+    """
+
+    pass

--- a/src/stk/ea/mutation/mutators/compound/random.py
+++ b/src/stk/ea/mutation/mutators/compound/random.py
@@ -82,7 +82,7 @@ class RandomMutator:
         :class:`.MutationPreconditionViolation`
             If the molecule which is meant to be mutated cannot be,
             because it does not satisfy the necessary preconditions for
-            the mutation operation. See the
+            the mutation operation. See
             :class:`.MutationPreconditionViolation` for more info.
 
         """

--- a/src/stk/ea/mutation/mutators/compound/random.py
+++ b/src/stk/ea/mutation/mutators/compound/random.py
@@ -77,8 +77,13 @@ class RandomMutator:
             :class:`.MutationRecord` depends on which mutator was
             used.
 
-        None : :class:`NoneType`
-            If `record` cannot be mutated.
+        Raises
+        ------
+        :class:`.MutationPreconditionViolation`
+            If the molecule which is meant to be mutated cannot be,
+            because it does not satisfy the necessary preconditions for
+            the mutation operation. See the
+            :class:`.MutationPreconditionViolation` for more info.
 
         """
 

--- a/src/stk/ea/mutation/mutators/molecule/mutator.py
+++ b/src/stk/ea/mutation/mutators/molecule/mutator.py
@@ -46,8 +46,15 @@ class MoleculeMutator:
         :class:`.MutationRecord`
             A record of the mutation.
 
-        None : :class:`NoneType`
-            If `record` cannot be mutated.
+        Raises
+        ------
+        :class:`.MutationPreconditionViolation`
+            If the molecule which is meant to be mutated cannot be,
+            because it does not satisfy the necessary preconditions for
+            the mutation operation. Reading the documentation of
+            :class:`.MutationPreconditionViolation`
+            is strongly strongly recommended for understanding why
+            you might want to raise this error.
 
         """
 

--- a/src/stk/ea/mutation/mutators/molecule/random_building_block.py
+++ b/src/stk/ea/mutation/mutators/molecule/random_building_block.py
@@ -106,6 +106,21 @@ class RandomBuildingBlock(MoleculeMutator):
         self._generator = np.random.RandomState(random_seed)
 
     def mutate(self, record):
+        """
+        Return a mutant of `record`.
+
+        Parameters
+        ----------
+        record : :class:`.MoleculeRecord`
+            The molecule to be mutated.
+
+        Returns
+        -------
+        :class:`.MutationRecord`
+            A record of the mutation.
+
+        """
+
         # Choose the building block which undergoes mutation.
         replaceable_building_blocks = tuple(filter(
             self._is_replaceable,

--- a/src/stk/ea/mutation/mutators/molecule/random_topology_graph.py
+++ b/src/stk/ea/mutation/mutators/molecule/random_topology_graph.py
@@ -83,6 +83,21 @@ class RandomTopologyGraph(MoleculeMutator):
         self._generator = np.random.RandomState(random_seed)
 
     def mutate(self, record):
+        """
+        Return a mutant of `record`.
+
+        Parameters
+        ----------
+        record : :class:`.MoleculeRecord`
+            The molecule to be mutated.
+
+        Returns
+        -------
+        :class:`.MutationRecord`
+            A record of the mutation.
+
+        """
+
         replacement_func = self._generator.choice(
             a=self._replacement_funcs,
         )

--- a/src/stk/ea/mutation/mutators/molecule/similar_building_block.py
+++ b/src/stk/ea/mutation/mutators/molecule/similar_building_block.py
@@ -117,6 +117,21 @@ class SimilarBuildingBlock(MoleculeMutator):
         self._similar_building_blocks = {}
 
     def mutate(self, record):
+        """
+        Return a mutant of `record`.
+
+        Parameters
+        ----------
+        record : :class:`.MoleculeRecord`
+            The molecule to be mutated.
+
+        Returns
+        -------
+        :class:`.MutationRecord`
+            A record of the mutation.
+
+        """
+
         key = self._key_maker.get_key(record.get_molecule())
         if key not in self._similar_building_blocks:
             # Maps the key to a dict. The dict maps each


### PR DESCRIPTION
I re-opened #250 for this. Basically, I do not like using `None` to indicate an expected failure in the `Mutator.mutate()` method because it loses a lot of information. For example, it is not clear why the failure happened, because there is no message and no way to distinguish different types of failure - they all return `None`. This API is also dangerous because I think it can be used by people to suppress errors which should not be suppressed. I.e by just returning `None` when there is *any* error, in order to suppress it and prevent the EA from crashing.

The solution to this is fairly obvious. `Mutator.mutate()` is allowed to raise specific types of exceptions, such as `MutationPreconditionViolation`, which the EA, which does the actual calling of `Mutator.mutate()`, can then expect and handle in a reasonable way. This system should be extensible, because we can introduce exceptions for other types of errors which we want to EA to handle. This system is very conservative about the types exceptions we expect the EA to handle, it does not introduce a general silencing mechanism. Also, because the allowed exception types are specific, like `MutationPreconditionViolation`, this is unlikely to get abused as a general error handling mechanism, for example by wrapping any error into a `MutationPreconditionViolation`. I think it would be obvious to any reasonable person that this would be bad form.

@andrewtarzia could you review this for me please? Also @stevenbennett96 I think this may be interesting to you.