### PR TITLE
Add ValueError for Macrocycle from 2 BBs

### DIFF
--- a/src/stk/molecular/topology_graphs/macrocycle/macrocycle.py
+++ b/src/stk/molecular/topology_graphs/macrocycle/macrocycle.py
@@ -245,6 +245,13 @@ class Macrocycle(TopologyGraph):
             orientations = orientations*num_repeating_units
 
         chain_length = len(repeating_unit)*num_repeating_units
+        if chain_length == 2:
+            raise ValueError(
+                'The orientation of macrocycles with chain length '
+                f'{chain_length} is not expected to provide robust '
+                'alignment and bonding.'
+            )
+
         if len(orientations) != chain_length:
             raise ValueError(
                 'The length of orientations must match either '

--- a/src/stk/molecular/topology_graphs/macrocycle/macrocycle.py
+++ b/src/stk/molecular/topology_graphs/macrocycle/macrocycle.py
@@ -5,6 +5,7 @@ Macrocycle
 """
 
 import numpy as np
+import warnings
 
 from .vertices import _CycleVertex
 from ..topology_graph import TopologyGraph, NullOptimizer, Edge
@@ -246,7 +247,7 @@ class Macrocycle(TopologyGraph):
 
         chain_length = len(repeating_unit)*num_repeating_units
         if chain_length == 2:
-            raise ValueError(
+            warnings.warn(
                 'The orientation of macrocycles with chain length '
                 f'{chain_length} is not expected to provide robust '
                 'alignment and bonding.'


### PR DESCRIPTION
Related Issues: #330
Requested Reviewers: @lukasturcani

This PR introduces an error to let the user know (in a hard way, because the output is nonsense) that alignment is not supported for Macrocycles formed from only 2 building blocks and 1 repeat unit. This is an edge use-case that I think can be fixed, with large rewrites of the Macrocycle class. A 2 building block Macrocycle also makes less sense, then using a different topology for that molecule.