### PR TITLE
Use Tuple

### DIFF
--- a/src/stk/molecular/topology_graphs/polymer/linear/linear.py
+++ b/src/stk/molecular/topology_graphs/polymer/linear/linear.py
@@ -6,6 +6,7 @@ Linear
 
 from dataclasses import dataclass
 import numpy as np
+from typing import Tuple
 
 from .vertices import (
     _HeadVertex,
@@ -457,5 +458,5 @@ class Linear(TopologyGraph):
 
 @dataclass(frozen=True)
 class VerticesAndEdges:
-    vertices: tuple[Vertex]
-    edges: tuple[Edge]
+    vertices: Tuple[Vertex]
+    edges: Tuple[Edge]


### PR DESCRIPTION

Requested Reviewers: @andrewtarzia  <!-- Add other reviewers here -->
*Note for Reviewers: If you accept the review request add a :+1: to this post*

Putting subscripts on the built-in tuple raises the requirement
for the minimum Python version to 3.9. To avoid doing this 
without notice, I'm switching to using `typing.Tuple` instead.