### PR TITLE
Implement Spinner optimizer with docs and tests.

### DIFF
--- a/docs/source/stk.molecular.topology_graphs.topology_graph.optimizers.rst
+++ b/docs/source/stk.molecular.topology_graphs.topology_graph.optimizers.rst
@@ -17,4 +17,5 @@ Submodules
    stk.molecular.topology_graphs.topology_graph.optimizers.null
    stk.molecular.topology_graphs.topology_graph.optimizers.optimizer
    stk.molecular.topology_graphs.topology_graph.optimizers.periodic_collapser
+   stk.molecular.topology_graphs.topology_graph.optimizers.spinner
    stk.molecular.topology_graphs.topology_graph.optimizers.utilities

--- a/docs/source/stk.molecular.topology_graphs.topology_graph.optimizers.spinner.rst
+++ b/docs/source/stk.molecular.topology_graphs.topology_graph.optimizers.spinner.rst
@@ -1,0 +1,4 @@
+.. automodule:: stk.molecular.topology_graphs.topology_graph.optimizers.spinner
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/setup.py
+++ b/setup.py
@@ -28,6 +28,7 @@ setup(
         'pymongo',
         'pymongo[srv]',
         'MCHammer',
+        'SpinDry',
     ),
     python_requires='>=3.7',
 )

--- a/src/stk/molecular/topology_graphs/host_guest/complex.py
+++ b/src/stk/molecular/topology_graphs/host_guest/complex.py
@@ -174,7 +174,7 @@ class Complex(TopologyGraph):
 
         complex = stk.ConstructedMolecule(
             topology_graph=stk.host_guest.Complex(
-                host=stk.BuildingBlock.init_from_molecule(host),
+                host=stk.BuildingBlock.init_from_molecule(cage),
                 guests=guest,
                 optimizer=stk.Spinner(),
             ),

--- a/src/stk/molecular/topology_graphs/host_guest/complex.py
+++ b/src/stk/molecular/topology_graphs/host_guest/complex.py
@@ -151,10 +151,34 @@ class Complex(TopologyGraph):
 
     *Suggested Optimization*
 
-    For :class:`.Complex` topologies, there is no need to use an
-    optimizer, so stick with :class:`.NullOptimizer`. However, it is
-    recommended that all building blocks be optimized prior to
-    construction.
+    For :class:`.Complex` topologies, it is recommended to use the
+    :class:`.Spinner` optimizer. It is also recommended that the
+    building blocks are already optimized prior to construction.
+
+    .. testcode:: suggested-optimization
+
+        import stk
+
+        bb1 = stk.BuildingBlock('NCCN', [stk.PrimaryAminoFactory()])
+        bb2 = stk.BuildingBlock(
+            smiles='O=CC(C=O)C=O',
+            functional_groups=[stk.AldehydeFactory()],
+        )
+        guest = stk.host_guest.Guest(stk.BuildingBlock('c1ccccc1'))
+        cage = stk.ConstructedMolecule(
+            topology_graph=stk.cage.FourPlusSix(
+                building_blocks=(bb1, bb2),
+                optimizer=stk.MCHammer(),
+            ),
+        )
+
+        complex = stk.ConstructedMolecule(
+            topology_graph=stk.host_guest.Complex(
+                host=stk.BuildingBlock.init_from_molecule(host),
+                guests=guest,
+                optimizer=stk.Spinner(),
+            ),
+        )
 
     *Changing the Position of the Guest*
 

--- a/src/stk/molecular/topology_graphs/host_guest/complex.py
+++ b/src/stk/molecular/topology_graphs/host_guest/complex.py
@@ -20,10 +20,10 @@ class Guest:
     def __init__(
         self,
         building_block: BuildingBlock,
-        start_vector: Tuple[float] = (1., 0., 0.),
-        end_vector: Tuple[float] = (1., 0., 0.),
-        displacement: Tuple[float] = (1., 0., 0.),
-    ):
+        start_vector: Tuple[float, float, float] = (1., 0., 0.),
+        end_vector: Tuple[float, float, float] = (1., 0., 0.),
+        displacement: Tuple[float, float, float] = (1., 0., 0.),
+    ) -> None:
         """
         Initialize a :class:`.Guest` instance.
 
@@ -107,106 +107,115 @@ class Complex(TopologyGraph):
 
     Host and guest building blocks do not require functional groups.
 
-    Examples
-    --------
-    *Construction*
+    Examples:
+        *Construction*
 
-    You can use :class:`.ConstructedMolecule` instances as the host,
-    but you should turn them into a :class:`.BuildingBlock` first
+        You can use :class:`.ConstructedMolecule` instances as the
+        host, but you should turn them into a :class:`.BuildingBlock`
+        first
 
-    .. testcode:: construction
+        .. testcode:: construction
 
-        import stk
+            import stk
 
-        host = stk.ConstructedMolecule(
-            topology_graph=stk.cage.FourPlusSix(
-                building_blocks=(
-                    stk.BuildingBlock('BrCCBr', [stk.BromoFactory()]),
-                    stk.BuildingBlock(
-                        smiles='BrCC(Br)CBr',
-                        functional_groups=[stk.BromoFactory()],
+            host = stk.ConstructedMolecule(
+                topology_graph=stk.cage.FourPlusSix(
+                    building_blocks=(
+                        stk.BuildingBlock(
+                            smiles='BrCCBr',
+                            functional_groups=[stk.BromoFactory()],
+                        ),
+                        stk.BuildingBlock(
+                            smiles='BrCC(Br)CBr',
+                            functional_groups=[stk.BromoFactory()],
+                        ),
                     ),
                 ),
-            ),
-        )
-        complex = stk.ConstructedMolecule(
-            topology_graph=stk.host_guest.Complex(
-                host=stk.BuildingBlock.init_from_molecule(host),
-                guests=stk.host_guest.Guest(
-                    building_block=stk.BuildingBlock('[Br][Br]'),
-                ),
-            ),
-        )
-
-    *Suggested Optimization*
-
-    For :class:`.Complex` topologies, it is recommended to use the
-    :class:`.Spinner` optimizer. It is also recommended that the
-    building blocks are already optimized prior to construction.
-
-    .. testcode:: suggested-optimization
-
-        import stk
-
-        bb1 = stk.BuildingBlock('NCCN', [stk.PrimaryAminoFactory()])
-        bb2 = stk.BuildingBlock(
-            smiles='O=CC(C=O)C=O',
-            functional_groups=[stk.AldehydeFactory()],
-        )
-        guest = stk.host_guest.Guest(stk.BuildingBlock('c1ccccc1'))
-        cage = stk.ConstructedMolecule(
-            topology_graph=stk.cage.FourPlusSix(
-                building_blocks=(bb1, bb2),
-                optimizer=stk.MCHammer(),
-            ),
-        )
-
-        complex = stk.ConstructedMolecule(
-            topology_graph=stk.host_guest.Complex(
-                host=stk.BuildingBlock.init_from_molecule(cage),
-                guests=guest,
-                optimizer=stk.Spinner(),
-            ),
-        )
-
-    *Changing the Position of the Guest*
-
-    You can change the position and orientation of the guest, as well
-    as its displacement
-
-    .. testcode:: changing-the-position-of-the-guest
-
-        import stk
-
-        host = stk.ConstructedMolecule(
-            topology_graph=stk.cage.FourPlusSix(
-                building_blocks=(
-                    stk.BuildingBlock('BrCCBr', [stk.BromoFactory()]),
-                    stk.BuildingBlock(
-                        smiles='BrCC(Br)CBr',
-                        functional_groups=[stk.BromoFactory()],
+            )
+            complex = stk.ConstructedMolecule(
+                topology_graph=stk.host_guest.Complex(
+                    host=stk.BuildingBlock.init_from_molecule(host),
+                    guests=stk.host_guest.Guest(
+                        building_block=stk.BuildingBlock('[Br][Br]'),
                     ),
                 ),
-            ),
-        )
+            )
 
-        guest_building_block = stk.BuildingBlock('[Br][Br]')
-        guest = stk.host_guest.Guest(
-            building_block=guest_building_block,
-            # Apply a rotation onto the guest molecule such that
-            # the vector returned by get_direction() has the same
-            # direction as [1, 1, 1].
-            start_vector=guest_building_block.get_direction(),
-            end_vector=[1, 1, 1],
-            # Change the displacement of the guest.
-            displacement=[5.3, 2.1, 7.1],
-        )
-        complex = stk.ConstructedMolecule(
-            topology_graph=stk.host_guest.Complex(
-                host=stk.BuildingBlock.init_from_molecule(host),
-                guests=guest,
-            ),
-        )
+        *Suggested Optimization*
+
+        For :class:`.Complex` topologies, it is recommended to use the
+        :class:`.Spinner` optimizer. It is also recommended that the
+        building blocks are already optimized prior to construction.
+
+        .. testcode:: suggested-optimization
+
+            import stk
+
+            bb1 = stk.BuildingBlock(
+                smiles='NCCN',
+                functional_groups=[stk.PrimaryAminoFactory()],
+            )
+            bb2 = stk.BuildingBlock(
+                smiles='O=CC(C=O)C=O',
+                functional_groups=[stk.AldehydeFactory()],
+            )
+            guest = stk.host_guest.Guest(stk.BuildingBlock('c1ccccc1'))
+            cage = stk.ConstructedMolecule(
+                topology_graph=stk.cage.FourPlusSix(
+                    building_blocks=(bb1, bb2),
+                    optimizer=stk.MCHammer(),
+                ),
+            )
+
+            complex = stk.ConstructedMolecule(
+                topology_graph=stk.host_guest.Complex(
+                    host=stk.BuildingBlock.init_from_molecule(cage),
+                    guests=guest,
+                    optimizer=stk.Spinner(),
+                ),
+            )
+
+        *Changing the Position of the Guest*
+
+        You can change the position and orientation of the guest, as
+        well as its displacement
+
+        .. testcode:: changing-the-position-of-the-guest
+
+            import stk
+
+            host = stk.ConstructedMolecule(
+                topology_graph=stk.cage.FourPlusSix(
+                    building_blocks=(
+                        stk.BuildingBlock(
+                            smiles='BrCCBr',
+                            functional_groups=[stk.BromoFactory()],
+                        ),
+                        stk.BuildingBlock(
+                            smiles='BrCC(Br)CBr',
+                            functional_groups=[stk.BromoFactory()],
+                        ),
+                    ),
+                ),
+            )
+
+            guest_building_block = stk.BuildingBlock('[Br][Br]')
+            guest = stk.host_guest.Guest(
+                building_block=guest_building_block,
+                # Apply a rotation onto the guest molecule such that
+                # the vector returned by get_direction() has the same
+                # direction as [1, 1, 1].
+                start_vector=guest_building_block.get_direction(),
+                end_vector=[1, 1, 1],
+                # Change the displacement of the guest.
+                displacement=[5.3, 2.1, 7.1],
+            )
+            complex = stk.ConstructedMolecule(
+                topology_graph=stk.host_guest.Complex(
+                    host=stk.BuildingBlock.init_from_molecule(host),
+                    guests=guest,
+                ),
+            )
 
     """
 
@@ -214,13 +223,13 @@ class Complex(TopologyGraph):
         self,
         host: BuildingBlock,
         guest: Optional[BuildingBlock] = None,
-        guest_start: Optional[Tuple[float]] = None,
-        guest_target: Optional[Tuple[float]] = None,
-        displacement: Optional[Tuple[float]] = None,
+        guest_start: Optional[Tuple[float, float, float]] = None,
+        guest_target: Optional[Tuple[float, float, float]] = None,
+        displacement: Optional[Tuple[float, float, float]] = None,
         guests: Optional[Iterable[Guest]] = None,
         num_processes: int = 1,
         optimizer: Optimizer = NullOptimizer(),
-    ):
+    ) -> None:
         """
         Initialize an instance of :class:`.Complex`.
 

--- a/src/stk/molecular/topology_graphs/host_guest/complex.py
+++ b/src/stk/molecular/topology_graphs/host_guest/complex.py
@@ -4,10 +4,10 @@ Host Guest Complex
 
 """
 
-from typing import Tuple
+from typing import Optional, Tuple, Iterable
 from ...molecules import BuildingBlock
 from .vertices import HostVertex, GuestVertex
-from ..topology_graph import TopologyGraph, NullOptimizer
+from ..topology_graph import TopologyGraph, NullOptimizer, Optimizer
 import warnings
 
 
@@ -47,52 +47,44 @@ class Guest:
         self._end_vector = end_vector
         self._displacement = displacement
 
-    def get_building_block(self):
+    def get_building_block(self) -> BuildingBlock:
         """
         Return the building block.
 
-        Returns
-        -------
-        :class:`.BuildingBlock`
+        Returns:
             The building block.
 
         """
 
         return self._building_block
 
-    def get_start_vector(self):
+    def get_start_vector(self) -> Tuple[float]:
         """
         Return the start vector.
 
-        Returns
-        -------
-        :class:`tuple` of :class:`float`
+        Returns:
             The start vector.
 
         """
 
         return self._start_vector
 
-    def get_end_vector(self):
+    def get_end_vector(self) -> Tuple[float]:
         """
         Return the end vector.
 
-        Returns
-        -------
-        :class:`tuple` of :class:`float`
+        Returns:
             The end vector.
 
         """
 
         return self._end_vector
 
-    def get_displacement(self):
+    def get_displacement(self) -> Tuple[float]:
         """
         Return the displacement.
 
-        Returns
-        -------
-        :class:`tuple` of :class:`float`
+        Returns:
             The displacement.
 
         """
@@ -220,71 +212,60 @@ class Complex(TopologyGraph):
 
     def __init__(
         self,
-        host,
-        guest=None,
-        guest_start=None,
-        guest_target=None,
-        displacement=None,
-        guests=None,
-        num_processes=1,
-        optimizer=NullOptimizer(),
+        host: BuildingBlock,
+        guest: Optional[BuildingBlock] = None,
+        guest_start: Optional[Tuple[float]] = None,
+        guest_target: Optional[Tuple[float]] = None,
+        displacement: Optional[Tuple[float]] = None,
+        guests: Optional[Iterable[Guest]] = None,
+        num_processes: int = 1,
+        optimizer: Optimizer = NullOptimizer(),
     ):
         """
         Initialize an instance of :class:`.Complex`.
 
-        Parameters
-        ----------
-        host : :class:`.BuildingBlock`
-            The host molecule.
+        Parameters:
+            host: The host molecule.
 
-        guests : :class:`iterable` of :class:`.Guest`, optional
-            The guest molecules. Can be a single :class:`.Guest`
-            instance if only one guest is being used.
+            guests: The guest molecules. Can be a single
+                :class:`.Guest` instance if only one guest is being
+                used.
 
-        guest : :class:`.BuildingBlock`, optional
-            The guest molecule. This API is deprecated and will be
-            removed in any :mod:`.stk` version released on, or after,
-            01/01/2022. Use the `guests` parameter instead.
+            guest: The guest molecule. This API is deprecated and will
+                be removed in any :mod:`.stk` version released on, or
+                after, 01/01/2022. Use the `guests` parameter instead.
 
-        guest_start : :class:`tuple` of :class:`float`, optional
-            A direction vector which gets aligned with `guest_target`.
-            This API is deprecated and will be removed in any
-            :mod:`.stk` version released on, or after, 01/01/2022.
-            Use the `guests` parameter instead.
+            guest_start: A direction vector which gets aligned with
+                `guest_target`. This API is deprecated and will be
+                removed in any :mod:`.stk` version released on, or
+                after, 01/01/2022. Use the `guests` parameter instead.
 
-        guest_target : :class:`tuple` of :class:`float`, optional
-            A direction vector which determines the rotation applied to
-            the `guest`. A rotation such that `guest_start` is
-            transformed into `guest_target` is applied. This API is
-            deprecated and will be removed in any :mod:`.stk` version
-            released on, or after, 01/01/2022. Use the `guests`
-            parameter instead.
+            guest_target: A direction vector which determines the
+                rotation applied to the `guest`. A rotation such that
+                `guest_start` is transformed into `guest_target` is
+                applied. This API is deprecated and will be removed in
+                any :mod:`.stk` version released on, or after,
+                01/01/2022. Use the `guests` parameter instead.
 
-        displacement : :class:`tuple` of :class:`float`, optional
-            The translational offset of the guest. This API is
-            deprecated and will be removed in any :mod:`.stk` version
-            released on, or after, 01/01/2022. Use the `guests`
-            parameter instead.
+            displacement: The translational offset of the guest. This
+                API is deprecated and will be removed in any
+                :mod:`.stk` version released on, or after, 01/01/2022.
+                Use the `guests` parameter instead.
 
-        num_processes : :class:`int`, optional
-            The number of parallel processes to create during
-            :meth:`construct`.
+            num_processes: The number of parallel processes to create
+                during :meth:`construct`.
 
-        optimizer : :class:`.Optimizer`, optional
-            Used to optimize the structure of the constructed
-            molecule.
+            optimizer: Used to optimize the structure of the
+                constructed molecule.
 
-        Raises
-        ------
-        :class:`TypeError`
-            If `guest_start` or `guest_target` is defined but the other
-            is not.
+        Raises:
+            :class:`TypeError`: If `guest_start` or `guest_target` is
+                defined but the other is not.
 
-        :class:`ValueError`
-            If the old API and new API are used simultaneously.
+            :class:`ValueError`: If the old API and new API are used
+                simultaneously.
 
-        :class:`RuntimeError:
-            If no guests are provided.
+            :class:`RuntimeError:: If no guests are provided.
 
         """
 

--- a/src/stk/molecular/topology_graphs/host_guest/complex.py
+++ b/src/stk/molecular/topology_graphs/host_guest/complex.py
@@ -4,10 +4,17 @@ Host Guest Complex
 
 """
 
-from typing import Optional, Tuple, Iterable
+from typing import Dict, Optional, Tuple, Iterable
+
 from ...molecules import BuildingBlock
 from .vertices import HostVertex, GuestVertex
-from ..topology_graph import TopologyGraph, NullOptimizer, Optimizer
+from ..topology_graph import (
+    TopologyGraph,
+    NullOptimizer,
+    Optimizer,
+    ConstructionState,
+    Vertex,
+)
 import warnings
 
 
@@ -58,7 +65,7 @@ class Guest:
 
         return self._building_block
 
-    def get_start_vector(self) -> Tuple[float]:
+    def get_start_vector(self) -> Tuple[float, float, float]:
         """
         Return the start vector.
 
@@ -69,7 +76,7 @@ class Guest:
 
         return self._start_vector
 
-    def get_end_vector(self) -> Tuple[float]:
+    def get_end_vector(self) -> Tuple[float, float, float]:
         """
         Return the end vector.
 
@@ -80,7 +87,7 @@ class Guest:
 
         return self._end_vector
 
-    def get_displacement(self) -> Tuple[float]:
+    def get_displacement(self) -> Tuple[float, float, float]:
         """
         Return the displacement.
 
@@ -91,7 +98,7 @@ class Guest:
 
         return self._displacement
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return (
             f'{self.__class__.__name__}('
             f'{self._building_block!r}, '
@@ -274,7 +281,7 @@ class Complex(TopologyGraph):
             :class:`ValueError`: If the old API and new API are used
                 simultaneously.
 
-            :class:`RuntimeError:: If no guests are provided.
+            :class:`RuntimeError`: If no guests are provided.
 
         """
 
@@ -326,7 +333,11 @@ class Complex(TopologyGraph):
             edge_groups=(),
         )
 
-    def _get_vertices_from_guests(self, host, guests):
+    def _get_vertices_from_guests(
+        self,
+        host: BuildingBlock,
+        guests: Iterable[Guest],
+    ) -> Dict[BuildingBlock, Vertex]:
         if isinstance(guests, Guest):
             guests = (guests, )
 
@@ -348,12 +359,12 @@ class Complex(TopologyGraph):
 
     def _get_vertices_from_guest(
         self,
-        host,
-        guest,
-        guest_start,
-        guest_target,
-        displacement,
-    ):
+        host: BuildingBlock,
+        guest: BuildingBlock,
+        guest_start: Tuple[float, float, float],
+        guest_target: Tuple[float, float, float],
+        displacement: Tuple[float, float, float],
+    ) -> Dict[BuildingBlock, Vertex]:
 
         num_nones = sum(
             1 for vector in (guest_start, guest_target)
@@ -385,15 +396,21 @@ class Complex(TopologyGraph):
 
         return building_block_vertices
 
-    def clone(self):
+    def clone(self) -> 'Complex':
         clone = super().clone()
         return clone
 
-    def _run_reactions(self, state):
+    def _run_reactions(
+        self,
+        state: ConstructionState,
+    ) -> ConstructionState:
         return state
 
-    def _get_scale(self, building_block_vertices):
-        return 1
+    def _get_scale(
+        self,
+        building_block_vertices: Dict[BuildingBlock, Vertex],
+    ) -> float:
+        return 1.
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return 'host_guest.Complex()'

--- a/src/stk/molecular/topology_graphs/host_guest/complex.py
+++ b/src/stk/molecular/topology_graphs/host_guest/complex.py
@@ -179,7 +179,7 @@ class Complex(TopologyGraph):
 
             complex = stk.ConstructedMolecule(
                 topology_graph=stk.host_guest.Complex(
-                    host=host,
+                    host=stk.BuildingBlock.init_from_molecule(host),
                     guests=(guest1, guest2),
                 ),
             )

--- a/src/stk/molecular/topology_graphs/host_guest/complex.py
+++ b/src/stk/molecular/topology_graphs/host_guest/complex.py
@@ -150,11 +150,46 @@ class Complex(TopologyGraph):
                 ),
             )
 
+        You can also generate complexes with multiple guests.
+
+        .. testcode:: multi-guest-construction
+
+            import stk
+
+            host = stk.ConstructedMolecule(
+                topology_graph=stk.cage.FourPlusSix(
+                    building_blocks=(
+                        stk.BuildingBlock(
+                            smiles='BrCCBr',
+                            functional_groups=[stk.BromoFactory()],
+                        ),
+                        stk.BuildingBlock(
+                            smiles='BrCC(Br)CBr',
+                            functional_groups=[stk.BromoFactory()],
+                        ),
+                    ),
+                ),
+            )
+            guest1 = stk.host_guest.Guest(
+                building_block=stk.BuildingBlock('c1ccccc1'),
+            )
+            guest2 = stk.host_guest.Guest(
+                building_block=stk.BuildingBlock('C1CCCC1'),
+            )
+
+            complex = stk.ConstructedMolecule(
+                topology_graph=stk.host_guest.Complex(
+                    host=host,
+                    guests=(guest1, guest2),
+                ),
+            )
+
         *Suggested Optimization*
 
         For :class:`.Complex` topologies, it is recommended to use the
         :class:`.Spinner` optimizer. It is also recommended that the
         building blocks are already optimized prior to construction.
+        This optimizer will work on multi-guest systems.
 
         .. testcode:: suggested-optimization
 

--- a/src/stk/molecular/topology_graphs/host_guest/complex.py
+++ b/src/stk/molecular/topology_graphs/host_guest/complex.py
@@ -4,6 +4,8 @@ Host Guest Complex
 
 """
 
+from typing import Tuple
+from ...molecules import BuildingBlock
 from .vertices import HostVertex, GuestVertex
 from ..topology_graph import TopologyGraph, NullOptimizer
 import warnings
@@ -17,31 +19,26 @@ class Guest:
 
     def __init__(
         self,
-        building_block,
-        start_vector=(1., 0., 0.),
-        end_vector=(1., 0., 0.),
-        displacement=(1., 0., 0.),
+        building_block: BuildingBlock,
+        start_vector: Tuple[float] = (1., 0., 0.),
+        end_vector: Tuple[float] = (1., 0., 0.),
+        displacement: Tuple[float] = (1., 0., 0.),
     ):
         """
         Initialize a :class:`.Guest` instance.
 
+        Parameters:
+            building_block: The guest molecule.
 
-        Parameters
-        ----------
-        building_block : :class:`.BuildingBlock`
-            The guest molecule.
+            start_vector: A direction vector which gets aligned with
+                `end_vector`.
 
-        start_vector : :class:`tuple` of :class:`float`, optional
-            A direction vector which gets aligned with `end_vector`.
+            end_vector: A direction vector which determines the
+                rotation applied to the `building_block`. A rotation
+                such that `start_vector` is transformed into
+                `end_vector` is applied.
 
-        end_vector : :class:`tuple` of :class:`float`, optional
-            A direction vector which determines the rotation applied to
-            the `building_block`. A rotation such that
-            `start_vector` is transformed into `end_vector`
-            is applied.
-
-        displacement : :class:`tuple` of :class:`float`, optional
-            The translational offset of the guest.
+            displacement: The translational offset of the guest.
 
         """
 

--- a/src/stk/molecular/topology_graphs/host_guest/complex.py
+++ b/src/stk/molecular/topology_graphs/host_guest/complex.py
@@ -4,7 +4,9 @@ Host Guest Complex
 
 """
 
-from typing import Dict, Optional, Tuple, Iterable
+from __future__ import annotations
+
+from typing import Optional, Iterable
 
 from ...molecules import BuildingBlock
 from .vertices import HostVertex, GuestVertex
@@ -27,9 +29,9 @@ class Guest:
     def __init__(
         self,
         building_block: BuildingBlock,
-        start_vector: Tuple[float, float, float] = (1., 0., 0.),
-        end_vector: Tuple[float, float, float] = (1., 0., 0.),
-        displacement: Tuple[float, float, float] = (1., 0., 0.),
+        start_vector: tuple[float, float, float] = (1., 0., 0.),
+        end_vector: tuple[float, float, float] = (1., 0., 0.),
+        displacement: tuple[float, float, float] = (1., 0., 0.),
     ) -> None:
         """
         Initialize a :class:`.Guest` instance.
@@ -65,7 +67,7 @@ class Guest:
 
         return self._building_block
 
-    def get_start_vector(self) -> Tuple[float, float, float]:
+    def get_start_vector(self) -> tuple[float, float, float]:
         """
         Return the start vector.
 
@@ -76,7 +78,7 @@ class Guest:
 
         return self._start_vector
 
-    def get_end_vector(self) -> Tuple[float, float, float]:
+    def get_end_vector(self) -> tuple[float, float, float]:
         """
         Return the end vector.
 
@@ -87,7 +89,7 @@ class Guest:
 
         return self._end_vector
 
-    def get_displacement(self) -> Tuple[float, float, float]:
+    def get_displacement(self) -> tuple[float, float, float]:
         """
         Return the displacement.
 
@@ -230,9 +232,9 @@ class Complex(TopologyGraph):
         self,
         host: BuildingBlock,
         guest: Optional[BuildingBlock] = None,
-        guest_start: Optional[Tuple[float, float, float]] = None,
-        guest_target: Optional[Tuple[float, float, float]] = None,
-        displacement: Optional[Tuple[float, float, float]] = None,
+        guest_start: Optional[tuple[float, float, float]] = None,
+        guest_target: Optional[tuple[float, float, float]] = None,
+        displacement: Optional[tuple[float, float, float]] = None,
         guests: Optional[Iterable[Guest]] = None,
         num_processes: int = 1,
         optimizer: Optimizer = NullOptimizer(),
@@ -337,7 +339,7 @@ class Complex(TopologyGraph):
         self,
         host: BuildingBlock,
         guests: Iterable[Guest],
-    ) -> Dict[BuildingBlock, Vertex]:
+    ) -> dict[BuildingBlock, Vertex]:
         if isinstance(guests, Guest):
             guests = (guests, )
 
@@ -361,10 +363,10 @@ class Complex(TopologyGraph):
         self,
         host: BuildingBlock,
         guest: BuildingBlock,
-        guest_start: Tuple[float, float, float],
-        guest_target: Tuple[float, float, float],
-        displacement: Tuple[float, float, float],
-    ) -> Dict[BuildingBlock, Vertex]:
+        guest_start: tuple[float, float, float],
+        guest_target: tuple[float, float, float],
+        displacement: tuple[float, float, float],
+    ) -> dict[BuildingBlock, Vertex]:
 
         num_nones = sum(
             1 for vector in (guest_start, guest_target)
@@ -396,7 +398,7 @@ class Complex(TopologyGraph):
 
         return building_block_vertices
 
-    def clone(self) -> 'Complex':
+    def clone(self) -> Complex:
         clone = super().clone()
         return clone
 
@@ -408,7 +410,7 @@ class Complex(TopologyGraph):
 
     def _get_scale(
         self,
-        building_block_vertices: Dict[BuildingBlock, Vertex],
+        building_block_vertices: dict[BuildingBlock, Vertex],
     ) -> float:
         return 1.
 

--- a/src/stk/molecular/topology_graphs/topology_graph/optimizers/__init__.py
+++ b/src/stk/molecular/topology_graphs/topology_graph/optimizers/__init__.py
@@ -3,4 +3,5 @@ from .optimizer import *  # noqa
 from .mchammer import *  # noqa
 from .collapser import *  # noqa
 from .periodic_collapser import *  # noqa
+from .spinner import *  # noqa
 from .utilities import *  # noqa

--- a/src/stk/molecular/topology_graphs/topology_graph/optimizers/optimizer.py
+++ b/src/stk/molecular/topology_graphs/topology_graph/optimizers/optimizer.py
@@ -17,6 +17,9 @@ periodic_collapser\
     MCHammer <\
 stk.molecular.topology_graphs.topology_graph.optimizers.mchammer\
 >
+    Spinner <\
+stk.molecular.topology_graphs.topology_graph.optimizers.spinner\
+>
 
     NullOptimizer <\
 stk.molecular.topology_graphs.topology_graph.optimizers.null\

--- a/src/stk/molecular/topology_graphs/topology_graph/optimizers/spinner.py
+++ b/src/stk/molecular/topology_graphs/topology_graph/optimizers/spinner.py
@@ -61,9 +61,8 @@ class Spinner(Optimizer):
         This code is entirely nonphysical and is, therefore, completely
         general to any chemistry.
 
-    References
-    ----------
-    .. [1] https://github.com/andrewtarzia/SpinDry
+    References:
+        .. [1] https://github.com/andrewtarzia/SpinDry
 
     """
 
@@ -93,12 +92,12 @@ class Spinner(Optimizer):
             max_attempts: Maximum number of MC moves to try to generate
                 conformers.
 
-            nonbond_epsilon: Value of epsilon used in the nonbond
+            nonbond_epsilon: Value of epsilon used in the nonbonded
                 potential in MC moves. Determines strength of the
-                nonbond potential.
+                nonbonded potential.
 
-            nonbond_sigma: Value of sigma used in the nonbond potential
-                in MC moves.
+            nonbond_sigma: Value of sigma used in the nonbonded
+                potential in MC moves.
 
             beta: Value of beta used in the in MC moves. Beta takes the
                 place of the inverse boltzmann temperature.
@@ -119,7 +118,6 @@ class Spinner(Optimizer):
         )
 
     def optimize(self, state: ConstructionState) -> ConstructionState:
-        # Define SpinDry supramolecule to optimize.
         supramolecule = spd.SupraMolecule(
             atoms=(
                 spd.Atom(
@@ -139,7 +137,6 @@ class Spinner(Optimizer):
             position_matrix=state.get_position_matrix(),
         )
 
-        # Run optimization.
         conformer = self._optimizer.get_final_conformer(supramolecule)
         return state.with_position_matrix(
             position_matrix=conformer.get_position_matrix(),

--- a/src/stk/molecular/topology_graphs/topology_graph/optimizers/spinner.py
+++ b/src/stk/molecular/topology_graphs/topology_graph/optimizers/spinner.py
@@ -5,6 +5,7 @@ Spinner
 """
 
 from .optimizer import Optimizer
+from ..construction_state import ConstructionState
 
 import spindry as spd
 
@@ -117,7 +118,7 @@ class Spinner(Optimizer):
             random_seed=random_seed,
         )
 
-    def optimize(self, state):
+    def optimize(self, state: ConstructionState) -> ConstructionState:
         # Define SpinDry supramolecule to optimize.
         supramolecule = spd.SupraMolecule(
             atoms=(

--- a/src/stk/molecular/topology_graphs/topology_graph/optimizers/spinner.py
+++ b/src/stk/molecular/topology_graphs/topology_graph/optimizers/spinner.py
@@ -60,50 +60,41 @@ class Spinner(Optimizer):
 
     def __init__(
         self,
-        step_size=1.5,
-        rotation_step_size=5,
-        num_conformers=50,
-        max_attempts=1000,
-        nonbond_epsilon=5,
-        nonbond_sigma=1.2,
-        beta=2,
-        random_seed=1000,
+        step_size: float = 1.5,
+        rotation_step_size: float = 5.,
+        num_conformers: int = 50,
+        max_attempts: int = 1000,
+        nonbond_epsilon: float = 5.,
+        nonbond_sigma: float = 1.2,
+        beta: float = 2.,
+        random_seed: int = 1000,
     ):
         """
         Initialize an instance of :class:`.Spinner`.
 
-        Parameters
-        ----------
-        step_size : :class:`float`
-            The relative size of the step to take during step.
+        Parameters:
+            step_size: The relative size of the step to take during
+                step.
 
-        rotation_step_size : :class:`float`
-            The relative size of the rotation to take during step.
+            rotation_step_size: The relative size of the rotation to
+                take during step.
 
-        num_conformers : :class:`int`
-            Number of conformers to extract.
+            num_conformers: Number of conformers to extract.
 
-        max_attempts : :class:`int`
-            Maximum number of MC moves to try to generate conformers.
+            max_attempts: Maximum number of MC moves to try to generate
+                conformers.
 
-        nonbond_epsilon : :class:`float`, optional
-            Value of epsilon used in the nonbond potential in MC moves.
-            Determines strength of the nonbond potential.
-            Defaults to 20.
+            nonbond_epsilon: Value of epsilon used in the nonbond
+                potential in MC moves. Determines strength of the
+                nonbond potential.
 
-        nonbond_sigma : :class:`float`, optional
-            Value of sigma used in the nonbond potential in MC moves.
-            Defaults to 1.2.
+            nonbond_sigma: Value of sigma used in the nonbond potential
+                in MC moves.
 
-        beta : :class:`float`, optional
-            Value of beta used in the in MC moves. Beta takes the
-            place of the inverse boltzmann temperature.
-            Defaults to 2.
+            beta: Value of beta used in the in MC moves. Beta takes the
+                place of the inverse boltzmann temperature.
 
-        random_seed : :class:`int` or :class:`NoneType`, optional
-            Random seed to use for MC algorithm. Should only be set to
-            ``None`` if system-based random seed is desired. Defaults
-            to 1000.
+            random_seed: Random seed to use for MC algorithm.
 
         """
 

--- a/src/stk/molecular/topology_graphs/topology_graph/optimizers/spinner.py
+++ b/src/stk/molecular/topology_graphs/topology_graph/optimizers/spinner.py
@@ -38,9 +38,10 @@ class Spinner(Optimizer):
                 optimizer=stk.MCHammer(),
             ),
         )
+
         complex = stk.ConstructedMolecule(
             topology_graph=stk.host_guest.Complex(
-                host=stk.BuildingBlock.init_from_molecule(host),
+                host=stk.BuildingBlock.init_from_molecule(cage),
                 guests=(guest1, guest2),
                 optimizer=stk.Spinner(),
             ),

--- a/src/stk/molecular/topology_graphs/topology_graph/optimizers/spinner.py
+++ b/src/stk/molecular/topology_graphs/topology_graph/optimizers/spinner.py
@@ -13,45 +13,52 @@ class Spinner(Optimizer):
     """
     Performs Monte Carlo optimisation of host-guest complexes [1]_.
 
-    Examples
-    --------
-    *Structure Optimization*
+    Examples:
+        *Structure Optimization*
 
-    Using :class:`.Spinner` will lead to :class:`.ConstructedMolecule`
-    structures with better host-guest structures. Especially useful
-    for multiple-guest systems and removing overlap.
+        Using :class:`.Spinner` will lead to
+        :class:`.ConstructedMolecule` structures with better host-guest
+        structures. Especially useful for multiple-guest systems and
+        removing overlap.
 
-    .. testcode:: structure-optimization
+        .. testcode:: structure-optimization
 
-        import stk
+            import stk
 
-        bb1 = stk.BuildingBlock('NCCN', [stk.PrimaryAminoFactory()])
-        bb2 = stk.BuildingBlock(
-            smiles='O=CC(C=O)C=O',
-            functional_groups=[stk.AldehydeFactory()],
-        )
-        guest1 = stk.host_guest.Guest(stk.BuildingBlock('c1ccccc1'))
-        guest2 = stk.host_guest.Guest(stk.BuildingBlock('C1CCCCC1'))
-        cage = stk.ConstructedMolecule(
-            topology_graph=stk.cage.FourPlusSix(
-                building_blocks=(bb1, bb2),
-                optimizer=stk.MCHammer(),
-            ),
-        )
+            bb1 = stk.BuildingBlock(
+                smiles='NCCN',
+                functional_groups=[stk.PrimaryAminoFactory()],
+            )
+            bb2 = stk.BuildingBlock(
+                smiles='O=CC(C=O)C=O',
+                functional_groups=[stk.AldehydeFactory()],
+            )
+            guest1 = stk.host_guest.Guest(
+                building_block=stk.BuildingBlock('c1ccccc1'),
+            )
+            guest2 = stk.host_guest.Guest(
+                building_block=stk.BuildingBlock('C1CCCCC1'),
+            )
+            cage = stk.ConstructedMolecule(
+                topology_graph=stk.cage.FourPlusSix(
+                    building_blocks=(bb1, bb2),
+                    optimizer=stk.MCHammer(),
+                ),
+            )
 
-        complex = stk.ConstructedMolecule(
-            topology_graph=stk.host_guest.Complex(
-                host=stk.BuildingBlock.init_from_molecule(cage),
-                guests=(guest1, guest2),
-                optimizer=stk.Spinner(),
-            ),
-        )
+            complex = stk.ConstructedMolecule(
+                topology_graph=stk.host_guest.Complex(
+                    host=stk.BuildingBlock.init_from_molecule(cage),
+                    guests=(guest1, guest2),
+                    optimizer=stk.Spinner(),
+                ),
+            )
 
-    Optimisation with :mod:`stk` simply collects the final position
-    matrix. The optimisation's trajectory can be output using the
-    :mod:`SpinDry` implementation if required by the user [1]_.
-    This code is entirely nonphysical and is, therefore, completely
-    general to any chemistry.
+        Optimisation with :mod:`stk` simply collects the final position
+        matrix. The optimisation's trajectory can be output using the
+        :mod:`SpinDry` implementation if required by the user [1]_.
+        This code is entirely nonphysical and is, therefore, completely
+        general to any chemistry.
 
     References
     ----------
@@ -69,7 +76,7 @@ class Spinner(Optimizer):
         nonbond_sigma: float = 1.2,
         beta: float = 2.,
         random_seed: int = 1000,
-    ):
+    ) -> None:
         """
         Initialize an instance of :class:`.Spinner`.
 

--- a/src/stk/molecular/topology_graphs/topology_graph/optimizers/spinner.py
+++ b/src/stk/molecular/topology_graphs/topology_graph/optimizers/spinner.py
@@ -1,0 +1,146 @@
+"""
+Spinner
+=======
+
+"""
+
+from .optimizer import Optimizer
+
+import spindry as spd
+
+
+class Spinner(Optimizer):
+    """
+    Performs Monte Carlo optimisation of host-guest complexes [1]_.
+
+    Examples
+    --------
+    *Structure Optimization*
+
+    Using :class:`.Spinner` will lead to :class:`.ConstructedMolecule`
+    structures with better host-guest structures. Especially useful
+    for multiple-guest systems and removing overlap.
+
+    .. testcode:: structure-optimization
+
+        import stk
+
+        bb1 = stk.BuildingBlock('NCCN', [stk.PrimaryAminoFactory()])
+        bb2 = stk.BuildingBlock(
+            smiles='O=CC(C=O)C=O',
+            functional_groups=[stk.AldehydeFactory()],
+        )
+        guest1 = stk.host_guest.Guest(stk.BuildingBlock('c1ccccc1'))
+        guest2 = stk.host_guest.Guest(stk.BuildingBlock('C1CCCCC1'))
+        cage = stk.ConstructedMolecule(
+            topology_graph=stk.cage.FourPlusSix(
+                building_blocks=(bb1, bb2),
+                optimizer=stk.MCHammer(),
+            ),
+        )
+        complex = stk.ConstructedMolecule(
+            topology_graph=stk.host_guest.Complex(
+                host=stk.BuildingBlock.init_from_molecule(host),
+                guests=(guest1, guest2),
+                optimizer=stk.Spinner(),
+            ),
+        )
+
+    Optimisation with :mod:`stk` simply collects the final position
+    matrix. The optimisation's trajectory can be output using the
+    :mod:`SpinDry` implementation if required by the user [1]_.
+    This code is entirely nonphysical and is, therefore, completely
+    general to any chemistry.
+
+    References
+    ----------
+    .. [1] https://github.com/andrewtarzia/SpinDry
+
+    """
+
+    def __init__(
+        self,
+        step_size=1.5,
+        rotation_step_size=5,
+        num_conformers=50,
+        max_attempts=1000,
+        nonbond_epsilon=5,
+        nonbond_sigma=1.2,
+        beta=2,
+        random_seed=1000,
+    ):
+        """
+        Initialize an instance of :class:`.Spinner`.
+
+        Parameters
+        ----------
+        step_size : :class:`float`
+            The relative size of the step to take during step.
+
+        rotation_step_size : :class:`float`
+            The relative size of the rotation to take during step.
+
+        num_conformers : :class:`int`
+            Number of conformers to extract.
+
+        max_attempts : :class:`int`
+            Maximum number of MC moves to try to generate conformers.
+
+        nonbond_epsilon : :class:`float`, optional
+            Value of epsilon used in the nonbond potential in MC moves.
+            Determines strength of the nonbond potential.
+            Defaults to 20.
+
+        nonbond_sigma : :class:`float`, optional
+            Value of sigma used in the nonbond potential in MC moves.
+            Defaults to 1.2.
+
+        beta : :class:`float`, optional
+            Value of beta used in the in MC moves. Beta takes the
+            place of the inverse boltzmann temperature.
+            Defaults to 2.
+
+        random_seed : :class:`int` or :class:`NoneType`, optional
+            Random seed to use for MC algorithm. Should only be set to
+            ``None`` if system-based random seed is desired. Defaults
+            to 1000.
+
+        """
+
+        self._optimizer = spd.Spinner(
+            step_size=step_size,
+            rotation_step_size=rotation_step_size,
+            num_conformers=num_conformers,
+            max_attempts=max_attempts,
+            nonbond_epsilon=nonbond_epsilon,
+            nonbond_sigma=nonbond_sigma,
+            beta=beta,
+            random_seed=random_seed,
+        )
+
+    def optimize(self, state):
+        # Define SpinDry supramolecule to optimize.
+        supramolecule = spd.SupraMolecule(
+            atoms=(
+                spd.Atom(
+                    id=atom.get_id(),
+                    element_string=atom.__class__.__name__,
+                ) for atom in state.get_atoms()
+            ),
+            bonds=(
+                spd.Bond(
+                    id=i,
+                    atom_ids=(
+                        bond.get_atom1().get_id(),
+                        bond.get_atom2().get_id(),
+                    )
+                ) for i, bond in enumerate(state.get_bonds())
+            ),
+            position_matrix=state.get_position_matrix(),
+        )
+
+        # Run optimization.
+        conformer = self._optimizer.get_final_conformer(supramolecule)
+        return state.with_position_matrix(
+            position_matrix=conformer.get_position_matrix(),
+        )

--- a/tests/docker/environment.yml
+++ b/tests/docker/environment.yml
@@ -112,4 +112,5 @@ dependencies:
     - seaborn==0.11.1
     - sphinx==3.5.4
     - sphinx_rtd_theme==0.5.2
+    - spindry==0.0.3
     - toml==0.10.2

--- a/tests/molecular/molecules/molecule/fixtures/host_guest/complex.py
+++ b/tests/molecular/molecules/molecule/fixtures/host_guest/complex.py
@@ -90,6 +90,23 @@ _guests = (
                 '.[H]C#C[H].[H]C#N'
             ),
         ),
+        CaseData(
+            molecule=stk.ConstructedMolecule(
+                topology_graph=stk.host_guest.Complex(
+                    host=stk.BuildingBlock.init_from_molecule(_cage),
+                    guests=(i for i in _guests),
+                    optimizer=stk.Spinner(),
+                )
+            ),
+            smiles=(
+                'F[C+]1[C+2]C23[C+2][C+]4[C+2][C+](C5=C(N=[C+]5)[C+]5'
+                '[C+2][C+]6[C+2]C7([C+2][CH+][C+]57)C5=C([C+]=[C+]5)['
+                'C+]5[C+2][C+]([C+2]C7([C+2][CH+][C+]57)C5=C2[C+]=[C+'
+                ']5)C2=C([C+]=[C+]2)[C+]2[C+2][C+](C5=C4[C+]=[C+]5)[C'
+                '+]4[CH+][C+2]C4([C+2]2)C2=C6[C+]=[C+]2)[C+]13'
+                '.[H]C#C[H].[H]C#N'
+            ),
+        ),
     ),
 )
 def host_guest_complex(request):


### PR DESCRIPTION
Requested Reviewers: @lukasturcani 
*Note for Reviewers: If you accept the review request add a :+1: to this post*

Simply add another optimizer called Spinner, which is made to optimize/generate conformers of host-guest pairs. This is most crucial for systems with multiple guests that may have overlapping structures.

I followed the same approach as the mchammer optimizers (effectively the same interface and code).

Adds a new dependency. It is small, but worth making the decision about its inclusion.


minimum working example (tests also included) - compare the two output structures.:

```python
import stk

host = stk.ConstructedMolecule(
    topology_graph=stk.cage.FourPlusSix(
        building_blocks=(
            stk.BuildingBlock('BrCCBr', [stk.BromoFactory()]),
            stk.BuildingBlock(
                smiles='BrCC(Br)CBr',
                functional_groups=[stk.BromoFactory()],
            ),
        ),
    ),
)
host = stk.BuildingBlock.init_from_molecule(host)
guest1_bb = stk.BuildingBlock('c1ccccc1')
guest1 = stk.host_guest.Guest(
    building_block=guest1_bb,
    start_vector=guest1_bb.get_direction(),
    end_vector=(1., 0., 0.),
    displacement=(0, 0, 0),
)
guest2_bb = stk.BuildingBlock('C1CCCC1')
guest2 = stk.host_guest.Guest(
    building_block=guest2_bb,
    start_vector=guest2_bb.get_direction(),
    end_vector=(0., 1., 0.),
    displacement=(0, 0, 0),
)

complex.write('complex_2.mol')
complex = stk.ConstructedMolecule(
    topology_graph=stk.host_guest.Complex(
        host=host,
        guests=(guest1, guest2),
    ),
)
complex.write('complex_3.mol')

complex = stk.ConstructedMolecule(
    topology_graph=stk.host_guest.Complex(
        host=host,
        guests=(guest1, guest2),
        optimizer=stk.Spinner(),
    ),
)
complex.write('complex_3_opt.mol')

```
