### PR TITLE
User Writer class in docs.

### DIFF
--- a/docs/source/basic_ea_example.rst
+++ b/docs/source/basic_ea_example.rst
@@ -654,8 +654,6 @@ The final version of our code is
         )
         building_block.with_position_matrix(
             position_matrix=get_position_matrix(building_block),
-            ),
-            path=path,
         )
 
 

--- a/docs/source/basic_ea_example.rst
+++ b/docs/source/basic_ea_example.rst
@@ -654,7 +654,7 @@ The final version of our code is
         )
         building_block.with_position_matrix(
             position_matrix=get_position_matrix(building_block),
-        )
+        ).write(path)
 
 
     def main():

--- a/docs/source/basic_ea_example.rst
+++ b/docs/source/basic_ea_example.rst
@@ -71,13 +71,15 @@ you can write each molecule in each generation to a file
 .. code-block:: python
 
     # Go through 50 generations of the EA.
+    writer = stk.MolWriter()
     for i, generation in enumerate(ea.get_generations(50)):
         # Go through the molecules in the generation, and write them
         # to a file.
         for molecule_id, molecule_record in enumerate(
             generation.get_molecule_records()
         ):
-            molecule_record.get_molecule().write(
+            writer.write(
+                molecule=molecule_record.get_molecule(),
                 path=f'generation_{i}_molecule_{molecule_id}.mol',
             )
 
@@ -652,7 +654,9 @@ The final version of our code is
         )
         building_block.with_position_matrix(
             position_matrix=get_position_matrix(building_block),
-        ).write(path)
+            ),
+            path=path,
+        )
 
 
     def main():

--- a/docs/source/basic_examples.rst
+++ b/docs/source/basic_examples.rst
@@ -331,7 +331,7 @@ This works with any :class:`.Molecule`, including both the
         smiles='ICCBr',
         functional_groups=[stk.BromoFactory(), stk.IodoFactory()],
     )
-    bb.write('bb.mol')
+    stk.MolWriter().write(bb, 'bb.mol')
 
 .. testcode:: writing-molecular-files
     :hide:
@@ -347,7 +347,7 @@ and the :class:`.ConstructedMolecule`
     polymer = stk.ConstructedMolecule(
         topology_graph=stk.polymer.Linear((bb, ), 'A', 10),
     )
-    polymer.write('polymer.mol')
+    stk.MolWriter().write(polymer, 'polymer.mol')
 
 
 .. testcode:: writing-molecular-files

--- a/docs/source/construction_overview.rst
+++ b/docs/source/construction_overview.rst
@@ -41,7 +41,7 @@ else, take for example the construction of a linear polymer
         )
     )
     # You can write the molecule to a file if you want to view it.
-    polymer.write('polymer.mol')
+    stk.MolWriter().write(polymer, 'polymer.mol')
 
 .. testcode:: introduction
     :hide:


### PR DESCRIPTION
Related Issues: #349 
Requested Reviewers: @lukasturcani
*Note for Reviewers: If you accept the review request add a :+1: to this post*

This PR simply replaces examples of `Molecule.write(path)` with `stk.Writer().write(molecule, path)` in prominent places that do not affect convenience (e.g. in the EA runs, some places should stay in the original version because of actual convenience and unclear file type expectations).
