### PR TITLE
Add BuildingBlock.get_num_placers()

### DIFF
--- a/src/stk/molecular/molecules/building_block.py
+++ b/src/stk/molecular/molecules/building_block.py
@@ -785,7 +785,7 @@ class BuildingBlock(Molecule):
 
         Returns:
 
-            The number of placer atoms in the building block.
+            The number of *placer* atoms in the building block.
 
         """
 

--- a/src/stk/molecular/molecules/building_block.py
+++ b/src/stk/molecular/molecules/building_block.py
@@ -779,6 +779,18 @@ class BuildingBlock(Molecule):
         clone._placer_ids = self._placer_ids
         return clone
 
+    def get_num_placers(self) -> int:
+        """
+        Return the number of *placer* atoms in the building block.
+
+        Returns:
+
+            The number of placer atoms in the building block.
+
+        """
+
+        return len(self._placer_ids)
+
     def get_placer_ids(self):
         """
         Yield the ids of *placer* atoms.

--- a/tests/molecular/molecules/building_block/test_get_num_placers.py
+++ b/tests/molecular/molecules/building_block/test_get_num_placers.py
@@ -1,0 +1,43 @@
+import stk
+
+from .case_data import CaseData
+
+
+def test_get_num_placers(case_data: CaseData) -> None:
+    """
+    Test :meth:`.BuildingBlock.get_num_placers`.
+
+    Parameters:
+
+        case_data:
+            A test case. Holds the building block to test and the
+            correct number of *placer* atoms.
+
+    """
+
+    _test_get_num_placers(
+        building_block=case_data.building_block,
+        expected_num_placers=len(case_data.placer_ids),
+    )
+
+
+def _test_get_num_placers(
+    building_block: stk.BuildingBlock,
+    expected_num_placers: int,
+) -> None:
+    """
+    Test :meth:`.BuildingBlock.get_num_placers`.
+
+    Parameters:
+
+        building_block:
+            The building block to test.
+
+        expected_num_placers:
+            The correct number of placer atoms
+
+    """
+
+    assert (
+        building_block.get_num_placers() == expected_num_placers
+    )

--- a/tests/molecular/molecules/building_block/test_get_num_placers.py
+++ b/tests/molecular/molecules/building_block/test_get_num_placers.py
@@ -34,7 +34,7 @@ def _test_get_num_placers(
             The building block to test.
 
         expected_num_placers:
-            The correct number of placer atoms
+            The correct number of *placer* atoms
 
     """
 


### PR DESCRIPTION
Related Issues: #376

Requested Reviewers: @andrewtarzia

A new method, `BuildingBlock.get_num_placers()` has been added. This
is necessary because sometimes the number of placer atoms is necessary,
for example, by unaligning vertices, which needs to check the number of
placer atoms, in order to determine if the unaligning vertex should be
used. Previously all the placer ids would have to be iterated though
with `BuildingBlock.get_placer_ids()`, which is both ugly and less
performant.

<!--
Talk about what a user would see (a big, a new feature) and what
user goals weren't being met. If the commit fixes a bug, describe how
the bug was discovered and steps to reproduce it, unless this is
already covered by the related issues. If this is a bug fix, what was
the mistake in the application logic? Be precise. Act like a detective
and report your findings.
-->

<!--
Why did you make the change this way? What other ways did you consider
but reject? Explain how amazing your work is.
-->

<!--
What risks are associated with making the changes in the commit? Will
anything else break? Are the changes backwards-compatible? Is there
any "tech debt"?
-->

<!--
Explain the source code changes. Changes that are fully explained in
code comments or the above paragraphs don't need to be repeated here.
Use bullet points, e.g.

* `src/stk/molecular/atoms/atom.py:Atom.get_id()`: The method
  parameters were updated because <some reason>. The places where
  the method was called were also updated.
-->

<!--
Give evidence that the commit works. Did you visually inspect any
changes to molecular structures yourself?
-->

<!--
The suggested PR outline is taken from
https://joshuatauberer.medium.com/write-joyous-git-commit-messages-2f98891114c4
-->
