### PR TITLE
Fix placer id representation of placer ids

### DIFF
--- a/src/stk/molecular/molecules/building_block.py
+++ b/src/stk/molecular/molecules/building_block.py
@@ -871,7 +871,7 @@ class BuildingBlock(Molecule):
         Yields
         ------
         :class:`int`
-            The id of a core atom.
+            The id of a *core* atom.
 
         See Also
         --------

--- a/src/stk/molecular/molecules/building_block.py
+++ b/src/stk/molecular/molecules/building_block.py
@@ -611,22 +611,23 @@ class BuildingBlock(Molecule):
             functional_groups=self._functional_groups,
         )
 
-    def _normalize_placer_ids(self, placer_ids, functional_groups):
+    def _normalize_placer_ids(
+        self,
+        placer_ids: tuple[int],
+        functional_groups: Iterable[FunctionalGroup],
+    ) -> set[int]:
         """
         Get the final *placer* ids.
 
-        Parameters
-        ----------
-        placer_ids : :class:`tuple` of :class:`int`
-            The ids of *placer* atoms or ``None``.
+        Parameters:
 
-        functional_groups : :class:`iterable`
-            The :class:`.FunctionalGroup` instances of the building
-            block.
+            placer_ids: The ids of *placer* atoms or ``None``.
 
-        Returns
-        -------
-        :class:`tuple` of :class:`int`
+            functional_groups:  The :class:`.FunctionalGroup` instances
+            of the building block.
+
+        Returns:
+
             Depending on the input  values, this function will return
             different things.
 
@@ -644,15 +645,15 @@ class BuildingBlock(Molecule):
         """
 
         if placer_ids is not None:
-            return placer_ids
+            return frozenset(placer_ids)
 
         if functional_groups:
-            return tuple(flatten(
+            return frozenset(flatten(
                 functional_group.get_placer_ids()
                 for functional_group in functional_groups
             ))
 
-        return tuple(atom.get_id() for atom in self._atoms)
+        return frozenset(atom.get_id() for atom in self._atoms)
 
     def _extract_functional_groups(self, functional_groups):
         """
@@ -725,7 +726,7 @@ class BuildingBlock(Molecule):
             functional_group.with_ids(id_map)
             for functional_group in self._functional_groups
         )
-        self._placer_ids = tuple(
+        self._placer_ids = frozenset(
             id_map[placer_id]
             for placer_id in self._placer_ids
         )

--- a/tests/molecular/molecules/building_block/fixtures/default_init.py
+++ b/tests/molecular/molecules/building_block/fixtures/default_init.py
@@ -76,6 +76,28 @@ from ..case_data import CaseData
             core_atom_ids=(0, 1, 2, 3),
             placer_ids=(0, 1, 2, 3),
         ),
+        lambda: CaseData(
+            building_block=stk.BuildingBlock(
+                smiles='Br[C+2]Br',
+                functional_groups=[stk.BromoFactory()],
+            ),
+            functional_groups=(
+                stk.Bromo(
+                    bromine=stk.Br(0),
+                    atom=stk.C(1, 2),
+                    bonders=(stk.C(1, 2), ),
+                    deleters=(stk.Br(0), ),
+                ),
+                stk.Bromo(
+                    bromine=stk.Br(2),
+                    atom=stk.C(1, 2),
+                    bonders=(stk.C(1, 2), ),
+                    deleters=(stk.Br(2), ),
+                ),
+            ),
+            core_atom_ids=(1, ),
+            placer_ids=(1, ),
+        ),
     ),
 )
 def default_init(request) -> CaseData:


### PR DESCRIPTION
Related Issues: #372 
Requested Reviewers: @lukasturcani 
*Note for Reviewers: If you accept the review request add a :+1: to this post*

Found, while working on #372, that BuildingBlock._placer_ids contained duplicate ids from distinct functional groups. This PR fixes this issue by using a frozen set in BuildingBlock.py.

Main change in 
* `src/stk/molecular/molecules/building_block.py:BuildingBlock._normalize_placer_ids()`: This method now returns a set.

Added a test of this specific issue.
