### PR TITLE
Add 3D Docs

### DIFF
--- a/docs/source/basic_examples.rst
+++ b/docs/source/basic_examples.rst
@@ -3,6 +3,11 @@ Basic Examples
 ==============
 
 
+.. note::
+
+    The molecules displayed are interactive renderings.
+
+
 Creating Building Blocks
 ========================
 
@@ -31,6 +36,32 @@ strings and loading them from molecule structure files.
 
     bb1 = stk.BuildingBlock('NCCCN')
     bb2 = stk.BuildingBlock.init_from_file('path/to/file.mol')
+
+.. moldoc::
+
+    import moldoc.molecule as molecule
+    import stk
+
+    bb1 = stk.BuildingBlock('NCCCN')
+
+    moldoc_display_molecule = molecule.Molecule(
+        atoms=(
+            molecule.Atom(
+                atomic_number=atom.get_atomic_number(),
+                position=position,
+            ) for atom, position in zip(
+                bb1.get_atoms(),
+                bb1.get_position_matrix(),
+            )
+        ),
+        bonds=(
+            molecule.Bond(
+                atom1_id=bond.get_atom1().get_id(),
+                atom2_id=bond.get_atom2().get_id(),
+                order=bond.get_order(),
+            ) for bond in bb1.get_bonds()
+        ),
+    )
 
 .. testcode:: creating-building-blocks
     :hide:
@@ -75,6 +106,32 @@ during construction, you would use a :class:`.BromoFactory`
     )
     assert bb.get_num_functional_groups() == 2
 
+.. moldoc::
+
+    import moldoc.molecule as molecule
+    import stk
+
+    bb = stk.BuildingBlock('BrCCCBr', [stk.BromoFactory()])
+
+    moldoc_display_molecule = molecule.Molecule(
+        atoms=(
+            molecule.Atom(
+                atomic_number=atom.get_atomic_number(),
+                position=position,
+            ) for atom, position in zip(
+                bb.get_atoms(),
+                bb.get_position_matrix(),
+            )
+        ),
+        bonds=(
+            molecule.Bond(
+                atom1_id=bond.get_atom1().get_id(),
+                atom2_id=bond.get_atom2().get_id(),
+                order=bond.get_order(),
+            ) for bond in bb.get_bonds()
+        ),
+    )
+
 The ``bb``, in the example above, would have two :class:`.Bromo`
 functional groups. Similarly, if you have a building block with
 aldehyde groups
@@ -91,6 +148,32 @@ aldehyde groups
         for fg in bb2.get_functional_groups()
     )
     assert bb2.get_num_functional_groups() == 2
+
+.. moldoc::
+
+    import moldoc.molecule as molecule
+    import stk
+
+    bb = stk.BuildingBlock('O=CCCC=O', [stk.AldehydeFactory()])
+
+    moldoc_display_molecule = molecule.Molecule(
+        atoms=(
+            molecule.Atom(
+                atomic_number=atom.get_atomic_number(),
+                position=position,
+            ) for atom, position in zip(
+                bb.get_atoms(),
+                bb.get_position_matrix(),
+            )
+        ),
+        bonds=(
+            molecule.Bond(
+                atom1_id=bond.get_atom1().get_id(),
+                atom2_id=bond.get_atom2().get_id(),
+                order=bond.get_order(),
+            ) for bond in bb.get_bonds()
+        ),
+    )
 
 In this example, ``bb2`` will have two :class:`.Aldehyde` functional
 groups. Finally, if you have both aldehyde and bromo groups on a
@@ -110,6 +193,35 @@ you would use both of the factories
     assert (
         set(map(type, bb3.get_functional_groups()))
         == {stk.Aldehyde, stk.Bromo}
+    )
+
+.. moldoc::
+
+    import moldoc.molecule as molecule
+    import stk
+
+    bb = stk.BuildingBlock(
+        smiles='O=CCCBr',
+        functional_groups=[stk.AldehydeFactory(), stk.BromoFactory()],
+    )
+
+    moldoc_display_molecule = molecule.Molecule(
+        atoms=(
+            molecule.Atom(
+                atomic_number=atom.get_atomic_number(),
+                position=position,
+            ) for atom, position in zip(
+                bb.get_atoms(),
+                bb.get_position_matrix(),
+            )
+        ),
+        bonds=(
+            molecule.Bond(
+                atom1_id=bond.get_atom1().get_id(),
+                atom2_id=bond.get_atom2().get_id(),
+                order=bond.get_order(),
+            ) for bond in bb.get_bonds()
+        ),
     )
 
 In the example above, ``bb3`` has one :class:`.Bromo` and one
@@ -136,16 +248,90 @@ a :class:`.TopologyGraph`, which, in turn,  requires
         topology_graph=stk.polymer.Linear(
             building_blocks=(bb1, bb2),
             repeating_unit='AB',
-            num_repeating_units=12,
+            num_repeating_units=4,
+            optimizer=stk.Collapser(scale_steps=False),
         ),
     )
+
+.. moldoc::
+
+    import moldoc.molecule as molecule
+    import stk
+
+    bb1 = stk.BuildingBlock('NCCN', [stk.PrimaryAminoFactory()])
+    bb2 = stk.BuildingBlock('O=CCCC=O', [stk.AldehydeFactory()])
+    polymer = stk.ConstructedMolecule(
+        topology_graph=stk.polymer.Linear(
+            building_blocks=(bb1, bb2),
+            repeating_unit='AB',
+            num_repeating_units=4,
+            optimizer=stk.Collapser(scale_steps=False),
+        ),
+    )
+
+    moldoc_display_molecule = molecule.Molecule(
+        atoms=(
+            molecule.Atom(
+                atomic_number=atom.get_atomic_number(),
+                position=position,
+            ) for atom, position in zip(
+                polymer.get_atoms(),
+                polymer.get_position_matrix(),
+            )
+        ),
+        bonds=(
+            molecule.Bond(
+                atom1_id=bond.get_atom1().get_id(),
+                atom2_id=bond.get_atom2().get_id(),
+                order=bond.get_order(),
+            ) for bond in polymer.get_bonds()
+        ),
+    )
+
+.. testcode:: constructing-molecules
 
     # Build a longer polymer.
     longer = stk.ConstructedMolecule(
         topology_graph=stk.polymer.Linear(
             building_blocks=(bb1, bb2),
             repeating_unit='AB',
-            num_repeating_units=23,
+            num_repeating_units=8,
+            optimizer=stk.Collapser(scale_steps=False),
+        ),
+    )
+
+.. moldoc::
+
+    import moldoc.molecule as molecule
+    import stk
+
+    bb1 = stk.BuildingBlock('NCCN', [stk.PrimaryAminoFactory()])
+    bb2 = stk.BuildingBlock('O=CCCC=O', [stk.AldehydeFactory()])
+    polymer = stk.ConstructedMolecule(
+        topology_graph=stk.polymer.Linear(
+            building_blocks=(bb1, bb2),
+            repeating_unit='AB',
+            num_repeating_units=8,
+            optimizer=stk.Collapser(scale_steps=False),
+        ),
+    )
+
+    moldoc_display_molecule = molecule.Molecule(
+        atoms=(
+            molecule.Atom(
+                atomic_number=atom.get_atomic_number(),
+                position=position,
+            ) for atom, position in zip(
+                polymer.get_atoms(),
+                polymer.get_position_matrix(),
+            )
+        ),
+        bonds=(
+            molecule.Bond(
+                atom1_id=bond.get_atom1().get_id(),
+                atom2_id=bond.get_atom2().get_id(),
+                order=bond.get_order(),
+            ) for bond in polymer.get_bonds()
         ),
     )
 
@@ -153,10 +339,11 @@ a :class:`.TopologyGraph`, which, in turn,  requires
 .. testcode:: constructing-molecules
     :hide:
 
-    assert polymer.get_num_building_block(bb1) == 12
-    assert polymer.get_num_building_block(bb2) == 12
-    assert longer.get_num_building_block(bb1) == 23
-    assert longer.get_num_building_block(bb2) == 23
+    assert polymer.get_num_building_block(bb1) == 4
+    assert polymer.get_num_building_block(bb2) == 4
+    assert longer.get_num_building_block(bb1) == 8
+    assert longer.get_num_building_block(bb2) == 8
+
 
 Each topology graph requires different input parameters.
 For example, organic cage topology graphs only require the
@@ -179,6 +366,42 @@ For example, organic cage topology graphs only require the
 
     assert cage.get_num_building_block(bb1) == 6
     assert cage.get_num_building_block(cage_bb2) == 4
+
+.. moldoc::
+
+    import moldoc.molecule as molecule
+    import stk
+
+    bb1 = stk.BuildingBlock('NCCN', [stk.PrimaryAminoFactory()])
+    bb2 = stk.BuildingBlock(
+        smiles='O=CC(C=O)CC=O',
+        functional_groups=[stk.AldehydeFactory()],
+    )
+    cage = stk.ConstructedMolecule(
+        topology_graph=stk.cage.FourPlusSix((bb1, bb2)),
+    )
+
+    moldoc_display_molecule = molecule.Molecule(
+        atoms=(
+            molecule.Atom(
+                atomic_number=atom.get_atomic_number(),
+                position=position,
+            ) for atom, position in zip(
+                cage.get_atoms(),
+                cage.get_position_matrix(),
+            )
+        ),
+        bonds=(
+            molecule.Bond(
+                atom1_id=bond.get_atom1().get_id(),
+                atom2_id=bond.get_atom2().get_id(),
+                order=bond.get_order(),
+            ) for bond in cage.get_bonds()
+        ),
+    )
+
+Note that this structure is far from ideal, the next example shows
+how to make one with shorter bond lengths!
 
 
 Read the documentation for each kind of :class:`.TopologyGraph`, for
@@ -208,7 +431,7 @@ clashes occur.
             building_blocks=(bb1, bb2),
             repeating_unit='AB',
             num_repeating_units=3,
-            optimizer=stk.Collapser(),
+            optimizer=stk.Collapser(scale_steps=False),
         ),
     )
 
@@ -217,6 +440,42 @@ clashes occur.
 
     assert polymer.get_num_building_block(bb1) == 3
     assert polymer.get_num_building_block(bb2) == 3
+
+.. moldoc::
+
+    import moldoc.molecule as molecule
+    import stk
+
+    bb1 = stk.BuildingBlock('NCCN', [stk.PrimaryAminoFactory()])
+    bb2 = stk.BuildingBlock('O=CCCC=O', [stk.AldehydeFactory()])
+    polymer = stk.ConstructedMolecule(
+        topology_graph=stk.polymer.Linear(
+            building_blocks=(bb1, bb2),
+            repeating_unit='AB',
+            num_repeating_units=3,
+            optimizer=stk.Collapser(scale_steps=False),
+        ),
+    )
+
+    moldoc_display_molecule = molecule.Molecule(
+        atoms=(
+            molecule.Atom(
+                atomic_number=atom.get_atomic_number(),
+                position=position,
+            ) for atom, position in zip(
+                polymer.get_atoms(),
+                polymer.get_position_matrix(),
+            )
+        ),
+        bonds=(
+            molecule.Bond(
+                atom1_id=bond.get_atom1().get_id(),
+                atom2_id=bond.get_atom2().get_id(),
+                order=bond.get_order(),
+            ) for bond in polymer.get_bonds()
+        ),
+    )
+
 
 Similarly, :class:`.MCHammer` performs rigid translations of the
 building blocks either toward the centroid of the
@@ -227,29 +486,69 @@ interactions.
 
 .. testcode:: using-built-in-optimizers-during-construction
 
-    polymer2 = stk.ConstructedMolecule(
-        topology_graph=stk.polymer.Linear(
+    bb1 = stk.BuildingBlock('NCCN', [stk.PrimaryAminoFactory()])
+    bb2 = stk.BuildingBlock(
+        smiles='O=CC(C=O)CC=O',
+        functional_groups=[stk.AldehydeFactory()],
+    )
+    cage = stk.ConstructedMolecule(
+        topology_graph=stk.cage.FourPlusSix(
             building_blocks=(bb1, bb2),
-            repeating_unit='AB',
-            num_repeating_units=3,
-            optimizer=stk.MCHammer(num_steps=1500, step_size=0.15),
+            optimizer=stk.MCHammer(),
         ),
     )
 
 .. testcode:: using-built-in-optimizers-during-construction
     :hide:
 
-    assert polymer.get_num_building_block(bb1) == 3
-    assert polymer.get_num_building_block(bb2) == 3
+    assert cage.get_num_building_block(bb1) == 6
+    assert cage.get_num_building_block(bb2) == 4
 
-See also
+.. moldoc::
+
+    import moldoc.molecule as molecule
+    import stk
+
+    bb1 = stk.BuildingBlock('NCCN', [stk.PrimaryAminoFactory()])
+    bb2 = stk.BuildingBlock(
+        smiles='O=CC(C=O)CC=O',
+        functional_groups=[stk.AldehydeFactory()],
+    )
+    cage = stk.ConstructedMolecule(
+        topology_graph=stk.cage.FourPlusSix(
+            building_blocks=(bb1, bb2),
+            optimizer=stk.MCHammer(),
+        ),
+    )
+
+    moldoc_display_molecule = molecule.Molecule(
+        atoms=(
+            molecule.Atom(
+                atomic_number=atom.get_atomic_number(),
+                position=position,
+            ) for atom, position in zip(
+                cage.get_atoms(),
+                cage.get_position_matrix(),
+            )
+        ),
+        bonds=(
+            molecule.Bond(
+                atom1_id=bond.get_atom1().get_id(),
+                atom2_id=bond.get_atom2().get_id(),
+                order=bond.get_order(),
+            ) for bond in cage.get_bonds()
+        ),
+    )
+
+.. seealso::
+
     The :class:`.Collapser` and :class:`.MCHammer` optimizers use the
     algorithms from https://github.com/andrewtarzia/MCHammer.
-    :mod:`stk` returns the final molecule only but further visualisation of
-    the full trajectory and properties can be performed
-    using the :mod:`MCHammer` code explicitly. This is useful for
-    determining optimal optimization parameters, for which safe options
-    are provided by default in :mod:`stk`.
+    :mod:`stk` returns the final molecule only but further
+    visualisation of the full trajectory and properties can be
+    performed using the :mod:`MCHammer` code explicitly. This is useful
+    for determining optimal optimization parameters, for which safe
+    options are provided by default in :mod:`stk`.
 
 Using RDKit to Optimize Molecular Structures
 ============================================
@@ -288,12 +587,52 @@ after construction. One easy way to do is, is with the
         rdkit_bb.GetConformer().GetPositions(),
     ))
 
+
+.. moldoc::
+
+    import moldoc.molecule as molecule
+    import stk
+    import rdkit.Chem.AllChem as rdkit
+
+    bb = stk.BuildingBlock('BrCCBr', [stk.BromoFactory()])
+
+    # Optimize with the MMFF force field.
+
+    rdkit_bb = bb.to_rdkit_mol()
+    rdkit.SanitizeMol(rdkit_bb)
+    rdkit.MMFFOptimizeMolecule(rdkit_bb)
+
+    # stk molecules are immutable. with_position_matrix returns a
+    # a clone, holding the new position matrix.
+    bb = bb.with_position_matrix(
+        position_matrix=rdkit_bb.GetConformer().GetPositions(),
+    )
+
+    moldoc_display_molecule = molecule.Molecule(
+        atoms=(
+            molecule.Atom(
+                atomic_number=atom.get_atomic_number(),
+                position=position,
+            ) for atom, position in zip(
+                bb.get_atoms(),
+                bb.get_position_matrix(),
+            )
+        ),
+        bonds=(
+            molecule.Bond(
+                atom1_id=bond.get_atom1().get_id(),
+                atom2_id=bond.get_atom2().get_id(),
+                order=bond.get_order(),
+            ) for bond in bb.get_bonds()
+        ),
+    )
+
 or a :class:`.ConstructedMolecule`
 
 .. testcode:: using-rdkit-to-optimize-molecular-structures
 
     polymer = stk.ConstructedMolecule(
-        topology_graph=stk.polymer.Linear((bb, ), 'A', 15),
+        topology_graph=stk.polymer.Linear((bb, ), 'A', 8),
     )
 
     # Optimize with the MMFF force field.
@@ -315,6 +654,50 @@ or a :class:`.ConstructedMolecule`
         polymer.get_position_matrix(),
         rdkit_polymer.GetConformer().GetPositions(),
     ))
+
+
+.. moldoc::
+
+    import moldoc.molecule as molecule
+    import stk
+    import rdkit.Chem.AllChem as rdkit
+
+    bb = stk.BuildingBlock('BrCCBr', [stk.BromoFactory()])
+
+    polymer = stk.ConstructedMolecule(
+        topology_graph=stk.polymer.Linear((bb, ), 'A', 8),
+    )
+
+    # Optimize with the MMFF force field.
+
+    rdkit_polymer = polymer.to_rdkit_mol()
+    rdkit.SanitizeMol(rdkit_polymer)
+    rdkit.MMFFOptimizeMolecule(rdkit_polymer)
+
+    # stk molecules are immutable. with_position_matrix returns a
+    # a clone, holding the new position matrix.
+    polymer = polymer.with_position_matrix(
+        position_matrix=rdkit_polymer.GetConformer().GetPositions(),
+    )
+
+    moldoc_display_molecule = molecule.Molecule(
+        atoms=(
+            molecule.Atom(
+                atomic_number=atom.get_atomic_number(),
+                position=position,
+            ) for atom, position in zip(
+                polymer.get_atoms(),
+                polymer.get_position_matrix(),
+            )
+        ),
+        bonds=(
+            molecule.Bond(
+                atom1_id=bond.get_atom1().get_id(),
+                atom2_id=bond.get_atom2().get_id(),
+                order=bond.get_order(),
+            ) for bond in polymer.get_bonds()
+        ),
+    )
 
 Writing Molecular Files
 =======================

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -37,6 +37,7 @@ extensions = [
     'sphinx.ext.viewcode',
     'sphinx.ext.doctest',
     'numpydoc',
+    'moldoc',
 ]
 
 autodoc_default_options = {

--- a/docs/source/construction_overview.rst
+++ b/docs/source/construction_overview.rst
@@ -57,7 +57,47 @@ else, take for example the construction of a linear polymer
 
 which will produce:
 
-.. image:: https://i.imgur.com/e782BBV.png
+.. moldoc::
+
+    import stk
+    import moldoc.molecule as molecule
+
+    polymer = stk.ConstructedMolecule(
+        topology_graph=stk.polymer.Linear(
+            building_blocks=(
+                stk.BuildingBlock(
+                    smiles='Brc1ccc(Br)cc1',
+                    functional_groups=[stk.BromoFactory()],
+                ),
+                stk.BuildingBlock(
+                    smiles='BrC#CBr',
+                    functional_groups=[stk.BromoFactory()],
+                ),
+            ),
+            repeating_unit='ABBA',
+            num_repeating_units=1,
+        ),
+    )
+
+    moldoc_display_molecule = molecule.Molecule(
+        atoms=(
+            molecule.Atom(
+                atomic_number=atom.get_atomic_number(),
+                position=position,
+            ) for atom, position in zip(
+                polymer.get_atoms(),
+                polymer.get_position_matrix(),
+            )
+        ),
+        bonds=(
+            molecule.Bond(
+                atom1_id=bond.get_atom1().get_id(),
+                atom2_id=bond.get_atom2().get_id(),
+                order=bond.get_order(),
+            ) for bond in polymer.get_bonds()
+        ),
+    )
+
 
 Because the topology graph is an idealized representation of the
 constructed molecule, the bonds formed during construction often have
@@ -66,17 +106,89 @@ undergo structure optimization. There is no single correct way to go
 about this, because the appropriate methodology for structure
 optimization will depend on various factors, such as the nature of the
 constructed molecule, the desired accuracy, and time constraints.
-In addition, there are countless options already available,
+
+However, :mod:`stk` does provide a handful of
+simple and lightweight methods for making structures more
+realistic, via optimizers
+
+.. testcode:: introduction
+
+    import stk
+
+    optimized_polymer = stk.ConstructedMolecule(
+        topology_graph=stk.polymer.Linear(
+            building_blocks=(
+                stk.BuildingBlock(
+                    smiles='Brc1ccc(Br)cc1',
+                    functional_groups=[stk.BromoFactory()],
+                ),
+                stk.BuildingBlock(
+                    smiles='BrC#CBr',
+                    functional_groups=[stk.BromoFactory()],
+                ),
+            ),
+            repeating_unit='ABBA',
+            num_repeating_units=1,
+            optimizer=stk.Collapser(scale_steps=False),
+        ),
+    )
+
+.. moldoc::
+
+    import stk
+    import moldoc.molecule as molecule
+
+    polymer = stk.ConstructedMolecule(
+        topology_graph=stk.polymer.Linear(
+            building_blocks=(
+                stk.BuildingBlock(
+                    smiles='Brc1ccc(Br)cc1',
+                    functional_groups=[stk.BromoFactory()],
+                ),
+                stk.BuildingBlock(
+                    smiles='BrC#CBr',
+                    functional_groups=[stk.BromoFactory()],
+                ),
+            ),
+            repeating_unit='ABBA',
+            num_repeating_units=1,
+            optimizer=stk.Collapser(scale_steps=False),
+        ),
+    )
+
+    moldoc_display_molecule = molecule.Molecule(
+        atoms=(
+            molecule.Atom(
+                atomic_number=atom.get_atomic_number(),
+                position=position,
+            ) for atom, position in zip(
+                polymer.get_atoms(),
+                polymer.get_position_matrix(),
+            )
+        ),
+        bonds=(
+            molecule.Bond(
+                atom1_id=bond.get_atom1().get_id(),
+                atom2_id=bond.get_atom2().get_id(),
+                order=bond.get_order(),
+            ) for bond in polymer.get_bonds()
+        ),
+    )
+
+
+:mod:`stk` only provides limited capacity in this regard because
+there are countless options already available,
 be it Python libraries such as :mod:`rdkit` or :mod:`ase`, or
-some sort of computational chemistry software. Since
-:mod:`stk` cannot hope to provide a good solution to this problem,
-it does try to make it easy for you to convert an
+some sort of computational chemistry software. In order to
+easily interact with these other tools, :mod:`stk` does try to make it
+easy for you to convert an
 :mod:`stk` :class:`.Molecule` into whatever format you need to make
 use of other software. This means you can access atoms and
 bonds with :meth:`.Molecule.get_atoms` and :meth:`.Molecule.get_bonds`,
 you can convert any :mod:`stk` :class:`.Molecule` into an
 :mod:`rdkit` molecule with :meth:`.Molecule.to_rdkit_mol` or you
-can write it to a file with :meth:`.Molecule.write`.
+can write it to a file using the various writer classes, such as
+:class:`.MolWriter`.
 
 .. figure:: https://i.imgur.com/UlCnTj9.png
     :align: center
@@ -166,6 +278,32 @@ during construction, you can use a :class:`.BromoFactory`.
     for fg in building_block.get_functional_groups():
         assert isinstance(fg, stk.Bromo)
 
+.. moldoc::
+
+    import moldoc.molecule as molecule
+    import stk
+
+    building_block = stk.BuildingBlock('BrCCBr', [stk.BromoFactory()])
+
+    moldoc_display_molecule = molecule.Molecule(
+        atoms=(
+            molecule.Atom(
+                atomic_number=atom.get_atomic_number(),
+                position=position,
+            ) for atom, position in zip(
+                building_block.get_atoms(),
+                building_block.get_position_matrix(),
+            )
+        ),
+        bonds=(
+            molecule.Bond(
+                atom1_id=bond.get_atom1().get_id(),
+                atom2_id=bond.get_atom2().get_id(),
+                order=bond.get_order(),
+            ) for bond in building_block.get_bonds()
+        ),
+    )
+
 In the example above, ``building_block`` will have two
 :class:`.Bromo` functional groups. When ``building_block`` is used
 for construction, it is the atoms held by the :class:`.Bromo`
@@ -187,6 +325,35 @@ aldehyde functional groups, we could have used an
     for fg in building_block2.get_functional_groups():
         assert isinstance(fg, stk.Aldehyde)
 
+.. moldoc::
+
+    import moldoc.molecule as molecule
+    import stk
+
+    building_block = stk.BuildingBlock(
+        smiles='O=CCC=O',
+        functional_groups=[stk.AldehydeFactory()],
+    )
+
+    moldoc_display_molecule = molecule.Molecule(
+        atoms=(
+            molecule.Atom(
+                atomic_number=atom.get_atomic_number(),
+                position=position,
+            ) for atom, position in zip(
+                building_block.get_atoms(),
+                building_block.get_position_matrix(),
+            )
+        ),
+        bonds=(
+            molecule.Bond(
+                atom1_id=bond.get_atom1().get_id(),
+                atom2_id=bond.get_atom2().get_id(),
+                order=bond.get_order(),
+            ) for bond in building_block.get_bonds()
+        ),
+    )
+
 Finally, if we had a mix of functional groups, we could have used
 a mix of factories
 
@@ -205,6 +372,35 @@ a mix of factories
         set(map(type, building_block3.get_functional_groups()))
         == {stk.Bromo, stk.Aldehyde}
      )
+
+.. moldoc::
+
+    import moldoc.molecule as molecule
+    import stk
+
+    building_block = stk.BuildingBlock(
+        smiles='O=CCCBr',
+        functional_groups=[stk.AldehydeFactory(), stk.BromoFactory()],
+    )
+
+    moldoc_display_molecule = molecule.Molecule(
+        atoms=(
+            molecule.Atom(
+                atomic_number=atom.get_atomic_number(),
+                position=position,
+            ) for atom, position in zip(
+                building_block.get_atoms(),
+                building_block.get_position_matrix(),
+            )
+        ),
+        bonds=(
+            molecule.Bond(
+                atom1_id=bond.get_atom1().get_id(),
+                atom2_id=bond.get_atom2().get_id(),
+                order=bond.get_order(),
+            ) for bond in building_block.get_bonds()
+        ),
+    )
 
 Based on the specific functional groups found on an
 edge of the :class:`.TopologyGraph`, :mod:`stk` will select an

--- a/docs/source/polymer.rst
+++ b/docs/source/polymer.rst
@@ -5,4 +5,4 @@ Polymer
 .. toctree::
     :maxdepth: 2
 
-    Linear <stk.molecular.topology_graphs.polymer.linear.linear>
+    Linear (this is a link, click me) <stk.molecular.topology_graphs.polymer.linear.linear>

--- a/src/stk/molecular/topology_graphs/cage/cage.py
+++ b/src/stk/molecular/topology_graphs/cage/cage.py
@@ -176,6 +176,39 @@ class Cage(TopologyGraph):
             topology_graph=stk.cage.FourPlusSix((bb1, bb2)),
         )
 
+    .. moldoc::
+
+        import moldoc.molecule as molecule
+        import stk
+
+        bb1 = stk.BuildingBlock('NCCN', [stk.PrimaryAminoFactory()])
+        bb2 = stk.BuildingBlock(
+            smiles='O=CC(C=O)C=O',
+            functional_groups=[stk.AldehydeFactory()],
+        )
+        cage = stk.ConstructedMolecule(
+            topology_graph=stk.cage.FourPlusSix((bb1, bb2)),
+        )
+
+        moldoc_display_molecule = molecule.Molecule(
+            atoms=(
+                molecule.Atom(
+                    atomic_number=atom.get_atomic_number(),
+                    position=position,
+                ) for atom, position in zip(
+                    cage.get_atoms(),
+                    cage.get_position_matrix(),
+                )
+            ),
+            bonds=(
+                molecule.Bond(
+                    atom1_id=bond.get_atom1().get_id(),
+                    atom2_id=bond.get_atom2().get_id(),
+                    order=bond.get_order(),
+                ) for bond in cage.get_bonds()
+            ),
+        )
+
     *Suggested Optimization*
 
     For :class:`.Cage` topologies, it is recommend to use the
@@ -199,6 +232,43 @@ class Cage(TopologyGraph):
             topology_graph=stk.cage.FourPlusSix(
                 building_blocks=(bb1, bb2),
                 optimizer=stk.MCHammer(),
+            ),
+        )
+
+    .. moldoc::
+
+        import moldoc.molecule as molecule
+        import stk
+
+        bb1 = stk.BuildingBlock('NCCN', [stk.PrimaryAminoFactory()])
+        bb2 = stk.BuildingBlock(
+            smiles='O=CC(C=O)C=O',
+            functional_groups=[stk.AldehydeFactory()],
+        )
+
+        cage = stk.ConstructedMolecule(
+            topology_graph=stk.cage.FourPlusSix(
+                building_blocks=(bb1, bb2),
+                optimizer=stk.MCHammer(),
+            ),
+        )
+
+        moldoc_display_molecule = molecule.Molecule(
+            atoms=(
+                molecule.Atom(
+                    atomic_number=atom.get_atomic_number(),
+                    position=position,
+                ) for atom, position in zip(
+                    cage.get_atoms(),
+                    cage.get_position_matrix(),
+                )
+            ),
+            bonds=(
+                molecule.Bond(
+                    atom1_id=bond.get_atom1().get_id(),
+                    atom2_id=bond.get_atom2().get_id(),
+                    order=bond.get_order(),
+                ) for bond in cage.get_bonds()
             ),
         )
 
@@ -260,9 +330,6 @@ class Cage(TopologyGraph):
 
         cage1 = stk.ConstructedMolecule(
             topology_graph=stk.cage.FourPlusSix(
-                # building_blocks is now a dict, which maps building
-                # blocks to the id of the vertices it should be placed
-                # on. You can use ranges to specify the ids.
                 building_blocks={
                     bb1: range(2),
                     bb2: (2, 3),
@@ -272,6 +339,58 @@ class Cage(TopologyGraph):
                 },
             ),
         )
+
+    .. moldoc::
+
+        import moldoc.molecule as molecule
+        import stk
+
+        bb1 = stk.BuildingBlock(
+            smiles='O=CC(C=O)C=O',
+            functional_groups=[stk.AldehydeFactory()],
+        )
+        bb2 = stk.BuildingBlock(
+            smiles='O=CC(Cl)(C=O)C=O',
+            functional_groups=[stk.AldehydeFactory()],
+        )
+        bb3 = stk.BuildingBlock('NCCN', [stk.PrimaryAminoFactory()])
+        bb4 = stk.BuildingBlock(
+            smiles='NCC(Cl)N',
+            functional_groups=[stk.PrimaryAminoFactory()],
+        )
+        bb5 = stk.BuildingBlock('NCCCCN', [stk.PrimaryAminoFactory()])
+
+        cage = stk.ConstructedMolecule(
+            topology_graph=stk.cage.FourPlusSix(
+                building_blocks={
+                    bb1: range(2),
+                    bb2: (2, 3),
+                    bb3: 4,
+                    bb4: 5,
+                    bb5: range(6, 10),
+                },
+            ),
+        )
+
+        moldoc_display_molecule = molecule.Molecule(
+            atoms=(
+                molecule.Atom(
+                    atomic_number=atom.get_atomic_number(),
+                    position=position,
+                ) for atom, position in zip(
+                    cage.get_atoms(),
+                    cage.get_position_matrix(),
+                )
+            ),
+            bonds=(
+                molecule.Bond(
+                    atom1_id=bond.get_atom1().get_id(),
+                    atom2_id=bond.get_atom2().get_id(),
+                    order=bond.get_order(),
+                ) for bond in cage.get_bonds()
+            ),
+        )
+
 
     You can combine this with the `vertex_alignments` parameter
 
@@ -286,7 +405,59 @@ class Cage(TopologyGraph):
                     bb4: 5,
                     bb5: range(6, 10),
                 },
-                vertex_alignments={0: 1, 1: 1, 2: 2},
+                vertex_alignments={5: 1},
+            ),
+        )
+
+    .. moldoc::
+
+        import moldoc.molecule as molecule
+        import stk
+
+        bb1 = stk.BuildingBlock(
+            smiles='O=CC(C=O)C=O',
+            functional_groups=[stk.AldehydeFactory()],
+        )
+        bb2 = stk.BuildingBlock(
+            smiles='O=CC(Cl)(C=O)C=O',
+            functional_groups=[stk.AldehydeFactory()],
+        )
+        bb3 = stk.BuildingBlock('NCCN', [stk.PrimaryAminoFactory()])
+        bb4 = stk.BuildingBlock(
+            smiles='NCC(Cl)N',
+            functional_groups=[stk.PrimaryAminoFactory()],
+        )
+        bb5 = stk.BuildingBlock('NCCCCN', [stk.PrimaryAminoFactory()])
+
+        cage = stk.ConstructedMolecule(
+            topology_graph=stk.cage.FourPlusSix(
+                building_blocks={
+                    bb1: range(2),
+                    bb2: (2, 3),
+                    bb3: 4,
+                    bb4: 5,
+                    bb5: range(6, 10),
+                },
+                vertex_alignments={5: 1},
+            ),
+        )
+
+        moldoc_display_molecule = molecule.Molecule(
+            atoms=(
+                molecule.Atom(
+                    atomic_number=atom.get_atomic_number(),
+                    position=position,
+                ) for atom, position in zip(
+                    cage.get_atoms(),
+                    cage.get_position_matrix(),
+                )
+            ),
+            bonds=(
+                molecule.Bond(
+                    atom1_id=bond.get_atom1().get_id(),
+                    atom2_id=bond.get_atom2().get_id(),
+                    order=bond.get_order(),
+                ) for bond in cage.get_bonds()
             ),
         )
 
@@ -340,12 +511,78 @@ class Cage(TopologyGraph):
                         bond_orders={
                             frozenset({
                                 stk.GenericFunctionalGroup,
-                                stk.SingleAtom
-                            }): 9
-                        }
-                    )
+                                stk.SingleAtom,
+                            }): 9,
+                        },
+                    ),
+                ),
+            ),
+        )
+
+    .. moldoc::
+
+        import moldoc.molecule as molecule
+        import stk
+
+        palladium_atom = stk.BuildingBlock(
+            smiles='[Pd+2]',
+            functional_groups=(
+                stk.SingleAtom(stk.Pd(0, charge=2))
+                for i in range(4)
+            ),
+            position_matrix=[[0., 0., 0.]],
+        )
+
+        bb1 = stk.BuildingBlock(
+            smiles=(
+                'C1=NC=CC(C2=CC=CC(C3=C'
+                'C=NC=C3)=C2)=C1'
+            ),
+            functional_groups=[
+                stk.SmartsFunctionalGroupFactory(
+                    smarts='[#6]~[#7X2]~[#6]',
+                    bonders=(1, ),
+                    deleters=(),
+                ),
+            ],
+        )
+
+        cage = stk.ConstructedMolecule(
+            stk.cage.M2L4Lantern(
+                building_blocks=(palladium_atom, bb1),
+                reaction_factory=stk.DativeReactionFactory(
+                    stk.GenericReactionFactory(
+                        bond_orders={
+                            # Use bond order of 1 here so that the
+                            # rendering does not show a bond order
+                            # of 9.
+                            frozenset({
+                                stk.GenericFunctionalGroup,
+                                stk.SingleAtom,
+                            }): 1,
+                        },
+                    ),
+                ),
+            ),
+        )
+
+        moldoc_display_molecule = molecule.Molecule(
+            atoms=(
+                molecule.Atom(
+                    atomic_number=atom.get_atomic_number(),
+                    position=position,
+                ) for atom, position in zip(
+                    cage.get_atoms(),
+                    cage.get_position_matrix(),
                 )
-            )
+            ),
+            bonds=(
+                molecule.Bond(
+                    atom1_id=bond.get_atom1().get_id(),
+                    atom2_id=bond.get_atom2().get_id(),
+                    order=bond.get_order(),
+                ) for bond in cage.get_bonds()
+            ),
         )
 
     *Controlling Metal-Complex Stereochemistry*
@@ -388,15 +625,75 @@ class Cage(TopologyGraph):
                     bonders=(1, ),
                     deleters=(),
                 ),
-            ]
+            ].
         )
 
         # Build iron complex with delta stereochemistry.
         iron_oct_delta = stk.ConstructedMolecule(
-            stk.metal_complex.OctahedralDelta(
+            topology_graph=stk.metal_complex.OctahedralDelta(
                 metals=iron_atom,
                 ligands=bb2,
-            )
+            ),
+        )
+
+    .. moldoc::
+
+        import moldoc.molecule as molecule
+        import stk
+
+        iron_atom = stk.BuildingBlock(
+            smiles='[Fe+2]',
+            functional_groups=(
+                stk.SingleAtom(stk.Fe(0, charge=2))
+                for i in range(6)
+            ),
+            position_matrix=[[0, 0, 0]],
+        )
+
+        bb2 = stk.BuildingBlock(
+            smiles='C1=NC(C=NBr)=CC=C1',
+            functional_groups=[
+                stk.SmartsFunctionalGroupFactory(
+                    smarts='[#6]~[#7X2]~[#35]',
+                    bonders=(1, ),
+                    deleters=(),
+                ),
+                stk.SmartsFunctionalGroupFactory(
+                    smarts='[#6]~[#7X2]~[#6]',
+                    bonders=(1, ),
+                    deleters=(),
+                ),
+            ],
+        )
+
+        complex = stk.ConstructedMolecule(
+            topology_graph=stk.metal_complex.OctahedralDelta(
+                metals=iron_atom,
+                ligands=bb2,
+            ),
+        )
+
+        moldoc_display_molecule = molecule.Molecule(
+            atoms=(
+                molecule.Atom(
+                    atomic_number=atom.get_atomic_number(),
+                    position=position,
+                ) for atom, position in zip(
+                    complex.get_atoms(),
+                    complex.get_position_matrix(),
+                )
+            ),
+            bonds=(
+                molecule.Bond(
+                    atom1_id=bond.get_atom1().get_id(),
+                    atom2_id=bond.get_atom2().get_id(),
+                    order=(
+                        1
+                        if bond.get_order() == 9
+                        else bond.get_order()
+                    ),
+                ) for bond in complex.get_bonds()
+            ),
         )
 
     Then the metal complexes can be placed on the appropriate
@@ -422,12 +719,95 @@ class Cage(TopologyGraph):
 
         # Build an M4L6 Tetrahedron with a spacer.
         cage2 = stk.ConstructedMolecule(
-            stk.cage.M4L6TetrahedronSpacer(
+            topology_graph=stk.cage.M4L6TetrahedronSpacer(
                 building_blocks=(
                     iron_oct_delta,
                     bb3,
                 ),
-            )
+            ),
+        )
+
+    .. moldoc::
+
+        import moldoc.molecule as molecule
+        import stk
+
+        iron_atom = stk.BuildingBlock(
+            smiles='[Fe+2]',
+            functional_groups=(
+                stk.SingleAtom(stk.Fe(0, charge=2))
+                for i in range(6)
+            ),
+            position_matrix=[[0, 0, 0]],
+        )
+
+        bb2 = stk.BuildingBlock(
+            smiles='C1=NC(C=NBr)=CC=C1',
+            functional_groups=[
+                stk.SmartsFunctionalGroupFactory(
+                    smarts='[#6]~[#7X2]~[#35]',
+                    bonders=(1, ),
+                    deleters=(),
+                ),
+                stk.SmartsFunctionalGroupFactory(
+                    smarts='[#6]~[#7X2]~[#6]',
+                    bonders=(1, ),
+                    deleters=(),
+                ),
+            ],
+        )
+
+        iron_oct_delta = stk.ConstructedMolecule(
+            topology_graph=stk.metal_complex.OctahedralDelta(
+                metals=iron_atom,
+                ligands=bb2,
+            ),
+        )
+
+        iron_oct_delta = stk.BuildingBlock.init_from_molecule(
+            molecule=iron_oct_delta,
+            functional_groups=[stk.BromoFactory()],
+        )
+
+        bb3 = stk.BuildingBlock(
+            smiles=(
+                'C1=CC(C2=CC=C(Br)C=C2)=C'
+                'C=C1Br'
+            ),
+            functional_groups=[stk.BromoFactory()],
+        )
+
+        cage = stk.ConstructedMolecule(
+            topology_graph=stk.cage.M4L6TetrahedronSpacer(
+                building_blocks=(
+                    iron_oct_delta,
+                    bb3,
+                ),
+            ),
+        )
+
+
+        moldoc_display_molecule = molecule.Molecule(
+            atoms=(
+                molecule.Atom(
+                    atomic_number=atom.get_atomic_number(),
+                    position=position,
+                ) for atom, position in zip(
+                    cage.get_atoms(),
+                    cage.get_position_matrix(),
+                )
+            ),
+            bonds=(
+                molecule.Bond(
+                    atom1_id=bond.get_atom1().get_id(),
+                    atom2_id=bond.get_atom2().get_id(),
+                    order=(
+                        1
+                        if bond.get_order() == 9
+                        else bond.get_order()
+                    ),
+                ) for bond in cage.get_bonds()
+            ),
         )
 
     *Aligning Metal Complex Building Blocks*
@@ -477,14 +857,14 @@ class Cage(TopologyGraph):
                     bonders=(0, ),
                     deleters=(),
                 ),
-            ]
+            ],
         )
 
         metal_complex = stk.ConstructedMolecule(
-            stk.metal_complex.CisProtectedSquarePlanar(
+            topology_graph=stk.metal_complex.CisProtectedSquarePlanar(
                 metals=metal_atom,
                 ligands=ligand,
-            )
+            ),
         )
 
     Next, we convert the metal complex into a :class:`.BuildingBlock`,
@@ -504,7 +884,7 @@ class Cage(TopologyGraph):
                     # for each functional group.
                     placers=(0, 1),
                 ),
-            ]
+            ],
         )
 
     We load in the organic linker of the cage as normal
@@ -519,7 +899,7 @@ class Cage(TopologyGraph):
                     bonders=(1, ),
                     deleters=(),
                 ),
-            ]
+            ],
         )
 
     And finally, we build the cage with a
@@ -528,7 +908,7 @@ class Cage(TopologyGraph):
     .. testcode:: aligning-metal-complex-building-blocks
 
         cage = stk.ConstructedMolecule(
-            stk.cage.M4L4Square(
+            topology_graph=stk.cage.M4L4Square(
                 corners=metal_complex,
                 linkers=linker,
                 reaction_factory=stk.DativeReactionFactory(
@@ -537,11 +917,11 @@ class Cage(TopologyGraph):
                             frozenset({
                                 stk.GenericFunctionalGroup,
                                 stk.GenericFunctionalGroup,
-                            }): 9
-                        }
-                    )
+                            }): 9,
+                        },
+                    ),
                 ),
-            )
+            ),
         )
 
     """

--- a/src/stk/molecular/topology_graphs/cage/cage.py
+++ b/src/stk/molecular/topology_graphs/cage/cage.py
@@ -625,7 +625,7 @@ class Cage(TopologyGraph):
                     bonders=(1, ),
                     deleters=(),
                 ),
-            ].
+            ],
         )
 
         # Build iron complex with delta stereochemistry.

--- a/src/stk/molecular/topology_graphs/cage/cage.py
+++ b/src/stk/molecular/topology_graphs/cage/cage.py
@@ -786,7 +786,6 @@ class Cage(TopologyGraph):
             ),
         )
 
-
         moldoc_display_molecule = molecule.Molecule(
             atoms=(
                 molecule.Atom(

--- a/src/stk/molecular/topology_graphs/cage/metal_topologies/m12l24.py
+++ b/src/stk/molecular/topology_graphs/cage/metal_topologies/m12l24.py
@@ -13,6 +13,63 @@ class M12L24(Cage):
     """
     Represents a cage topology graph.
 
+    .. moldoc::
+
+        import moldoc.molecule as molecule
+        import stk
+
+        bb1 = stk.BuildingBlock(
+            smiles='[Pd+2]',
+            functional_groups=(
+                stk.SingleAtom(stk.Pd(0, charge=2))
+                for i in range(4)
+            ),
+            position_matrix=[[0, 0, 0]],
+        )
+
+        bb2 = stk.BuildingBlock(
+            smiles=(
+                'C1=NC=CC(C2=CC=CC(C3=C'
+                'C=NC=C3)=C2)=C1'
+            ),
+            functional_groups=[
+                stk.SmartsFunctionalGroupFactory(
+                    smarts='[#6]~[#7X2]~[#6]',
+                    bonders=(1, ),
+                    deleters=(),
+                ),
+            ],
+        )
+
+        cage = stk.ConstructedMolecule(
+            topology_graph=stk.cage.M12L24(
+                building_blocks=(bb1, bb2),
+            ),
+        )
+
+        moldoc_display_molecule = molecule.Molecule(
+            atoms=(
+                molecule.Atom(
+                    atomic_number=atom.get_atomic_number(),
+                    position=position,
+                ) for atom, position in zip(
+                    cage.get_atoms(),
+                    cage.get_position_matrix(),
+                )
+            ),
+            bonds=(
+                molecule.Bond(
+                    atom1_id=bond.get_atom1().get_id(),
+                    atom2_id=bond.get_atom2().get_id(),
+                    order=(
+                        1
+                        if bond.get_order() == 9
+                        else bond.get_order()
+                    ),
+                ) for bond in cage.get_bonds()
+            ),
+        )
+
     Metal building blocks with four functional groups are
     required for this topology.
 

--- a/src/stk/molecular/topology_graphs/cage/metal_topologies/m24l48.py
+++ b/src/stk/molecular/topology_graphs/cage/metal_topologies/m24l48.py
@@ -13,6 +13,63 @@ class M24L48(Cage):
     """
     Represents a cage topology graph.
 
+    .. moldoc::
+
+        import moldoc.molecule as molecule
+        import stk
+
+        bb1 = stk.BuildingBlock(
+            smiles='[Pd+2]',
+            functional_groups=(
+                stk.SingleAtom(stk.Pd(0, charge=2))
+                for i in range(4)
+            ),
+            position_matrix=[[0, 0, 0]],
+        )
+
+        bb2 = stk.BuildingBlock(
+            smiles=(
+                'C1=NC=CC(C2=CC=CC(C3=C'
+                'C=NC=C3)=C2)=C1'
+            ),
+            functional_groups=[
+                stk.SmartsFunctionalGroupFactory(
+                    smarts='[#6]~[#7X2]~[#6]',
+                    bonders=(1, ),
+                    deleters=(),
+                ),
+            ],
+        )
+
+        cage = stk.ConstructedMolecule(
+            topology_graph=stk.cage.M24L48(
+                building_blocks=(bb1, bb2),
+            ),
+        )
+
+        moldoc_display_molecule = molecule.Molecule(
+            atoms=(
+                molecule.Atom(
+                    atomic_number=atom.get_atomic_number(),
+                    position=position,
+                ) for atom, position in zip(
+                    cage.get_atoms(),
+                    cage.get_position_matrix(),
+                )
+            ),
+            bonds=(
+                molecule.Bond(
+                    atom1_id=bond.get_atom1().get_id(),
+                    atom2_id=bond.get_atom2().get_id(),
+                    order=(
+                        1
+                        if bond.get_order() == 9
+                        else bond.get_order()
+                    ),
+                ) for bond in cage.get_bonds()
+            ),
+        )
+
     Metal building blocks with four functional groups are
     required for this topology.
 

--- a/src/stk/molecular/topology_graphs/cage/metal_topologies/m2l4_lantern.py
+++ b/src/stk/molecular/topology_graphs/cage/metal_topologies/m2l4_lantern.py
@@ -13,6 +13,125 @@ class M2L4Lantern(Cage):
     """
     Represents a cage topology graph.
 
+    Unoptimized construction
+
+    .. moldoc::
+
+        import moldoc.molecule as molecule
+        import stk
+
+        bb1 = stk.BuildingBlock(
+            smiles='[Pd+2]',
+            functional_groups=(
+                stk.SingleAtom(stk.Pd(0, charge=2))
+                for i in range(4)
+            ),
+            position_matrix=[[0, 0, 0]],
+        )
+
+        bb2 = stk.BuildingBlock(
+            smiles=(
+                'C1=NC=CC(C2=CC=CC(C3=C'
+                'C=NC=C3)=C2)=C1'
+            ),
+            functional_groups=[
+                stk.SmartsFunctionalGroupFactory(
+                    smarts='[#6]~[#7X2]~[#6]',
+                    bonders=(1, ),
+                    deleters=(),
+                ),
+            ],
+        )
+
+        cage = stk.ConstructedMolecule(
+            topology_graph=stk.cage.M2L4Lantern(
+                building_blocks=(bb1, bb2),
+            ),
+        )
+
+        moldoc_display_molecule = molecule.Molecule(
+            atoms=(
+                molecule.Atom(
+                    atomic_number=atom.get_atomic_number(),
+                    position=position,
+                ) for atom, position in zip(
+                    cage.get_atoms(),
+                    cage.get_position_matrix(),
+                )
+            ),
+            bonds=(
+                molecule.Bond(
+                    atom1_id=bond.get_atom1().get_id(),
+                    atom2_id=bond.get_atom2().get_id(),
+                    order=(
+                        1
+                        if bond.get_order() == 9
+                        else bond.get_order()
+                    ),
+                ) for bond in cage.get_bonds()
+            ),
+        )
+
+    :class:`.MCHammer` optimized construction
+
+    .. moldoc::
+
+        import moldoc.molecule as molecule
+        import stk
+
+        bb1 = stk.BuildingBlock(
+            smiles='[Pd+2]',
+            functional_groups=(
+                stk.SingleAtom(stk.Pd(0, charge=2))
+                for i in range(4)
+            ),
+            position_matrix=[[0, 0, 0]],
+        )
+
+        bb2 = stk.BuildingBlock(
+            smiles=(
+                'C1=NC=CC(C2=CC=CC(C3=C'
+                'C=NC=C3)=C2)=C1'
+            ),
+            functional_groups=[
+                stk.SmartsFunctionalGroupFactory(
+                    smarts='[#6]~[#7X2]~[#6]',
+                    bonders=(1, ),
+                    deleters=(),
+                ),
+            ],
+        )
+
+        cage = stk.ConstructedMolecule(
+            topology_graph=stk.cage.M2L4Lantern(
+                building_blocks=(bb1, bb2),
+                optimizer=stk.MCHammer(),
+            ),
+        )
+
+        moldoc_display_molecule = molecule.Molecule(
+            atoms=(
+                molecule.Atom(
+                    atomic_number=atom.get_atomic_number(),
+                    position=position,
+                ) for atom, position in zip(
+                    cage.get_atoms(),
+                    cage.get_position_matrix(),
+                )
+            ),
+            bonds=(
+                molecule.Bond(
+                    atom1_id=bond.get_atom1().get_id(),
+                    atom2_id=bond.get_atom2().get_id(),
+                    order=(
+                        1
+                        if bond.get_order() == 9
+                        else bond.get_order()
+                    ),
+                ) for bond in cage.get_bonds()
+            ),
+        )
+
     Metal building blocks with four functional groups are
     required for this topology.
 

--- a/src/stk/molecular/topology_graphs/cage/metal_topologies/m3l3_triangle.py
+++ b/src/stk/molecular/topology_graphs/cage/metal_topologies/m3l3_triangle.py
@@ -16,6 +16,127 @@ class M3L3Triangle(Cage):
     """
     Represents a cage topology graph.
 
+    Unoptimized construction
+
+    .. moldoc::
+
+        import moldoc.molecule as molecule
+        import stk
+
+        bb1 = stk.BuildingBlock(
+            smiles='[Pd+2]',
+            functional_groups=(
+                stk.SingleAtom(stk.Pd(0, charge=2))
+                for i in range(2)
+            ),
+            position_matrix=[[0, 0, 0]],
+        )
+
+        bb2 = stk.BuildingBlock(
+            smiles=(
+                'C1=NC=CC(C2=CC=CC(C3=C'
+                'C=NC=C3)=C2)=C1'
+            ),
+            functional_groups=[
+                stk.SmartsFunctionalGroupFactory(
+                    smarts='[#6]~[#7X2]~[#6]',
+                    bonders=(1, ),
+                    deleters=(),
+                ),
+            ],
+        )
+
+        cage = stk.ConstructedMolecule(
+            topology_graph=stk.cage.M3L3Triangle(
+                corners=bb1,
+                linkers=bb2,
+            ),
+        )
+
+        moldoc_display_molecule = molecule.Molecule(
+            atoms=(
+                molecule.Atom(
+                    atomic_number=atom.get_atomic_number(),
+                    position=position,
+                ) for atom, position in zip(
+                    cage.get_atoms(),
+                    cage.get_position_matrix(),
+                )
+            ),
+            bonds=(
+                molecule.Bond(
+                    atom1_id=bond.get_atom1().get_id(),
+                    atom2_id=bond.get_atom2().get_id(),
+                    order=(
+                        1
+                        if bond.get_order() == 9
+                        else bond.get_order()
+                    ),
+                ) for bond in cage.get_bonds()
+            ),
+        )
+
+    :class:`.MCHammer` optimized construction
+
+    .. moldoc::
+
+        import moldoc.molecule as molecule
+        import stk
+
+        bb1 = stk.BuildingBlock(
+            smiles='[Pd+2]',
+            functional_groups=(
+                stk.SingleAtom(stk.Pd(0, charge=2))
+                for i in range(2)
+            ),
+            position_matrix=[[0, 0, 0]],
+        )
+
+        bb2 = stk.BuildingBlock(
+            smiles=(
+                'C1=NC=CC(C2=CC=CC(C3=C'
+                'C=NC=C3)=C2)=C1'
+            ),
+            functional_groups=[
+                stk.SmartsFunctionalGroupFactory(
+                    smarts='[#6]~[#7X2]~[#6]',
+                    bonders=(1, ),
+                    deleters=(),
+                ),
+            ],
+        )
+
+        cage = stk.ConstructedMolecule(
+            topology_graph=stk.cage.M3L3Triangle(
+                corners=bb1,
+                linkers=bb2,
+                optimizer=stk.MCHammer(),
+            ),
+        )
+
+        moldoc_display_molecule = molecule.Molecule(
+            atoms=(
+                molecule.Atom(
+                    atomic_number=atom.get_atomic_number(),
+                    position=position,
+                ) for atom, position in zip(
+                    cage.get_atoms(),
+                    cage.get_position_matrix(),
+                )
+            ),
+            bonds=(
+                molecule.Bond(
+                    atom1_id=bond.get_atom1().get_id(),
+                    atom2_id=bond.get_atom2().get_id(),
+                    order=(
+                        1
+                        if bond.get_order() == 9
+                        else bond.get_order()
+                    ),
+                ) for bond in cage.get_bonds()
+            ),
+        )
+
     Both `corner` and `linker` vertices require building blocks with
     two functional groups for this topology. This class replaces the
     `building_blocks` parameter with the `corner` and `linker`

--- a/src/stk/molecular/topology_graphs/cage/metal_topologies/m3l6.py
+++ b/src/stk/molecular/topology_graphs/cage/metal_topologies/m3l6.py
@@ -15,6 +15,125 @@ class M3L6(Cage):
     """
     Represents a cage topology graph.
 
+    Unoptimized construction
+
+    .. moldoc::
+
+        import moldoc.molecule as molecule
+        import stk
+
+        bb1 = stk.BuildingBlock(
+            smiles='[Pd+2]',
+            functional_groups=(
+                stk.SingleAtom(stk.Pd(0, charge=2))
+                for i in range(4)
+            ),
+            position_matrix=[[0, 0, 0]],
+        )
+
+        bb2 = stk.BuildingBlock(
+            smiles=(
+                'C1=NC=CC(C2=CC=CC(C3=C'
+                'C=NC=C3)=C2)=C1'
+            ),
+            functional_groups=[
+                stk.SmartsFunctionalGroupFactory(
+                    smarts='[#6]~[#7X2]~[#6]',
+                    bonders=(1, ),
+                    deleters=(),
+                ),
+            ],
+        )
+
+        cage = stk.ConstructedMolecule(
+            topology_graph=stk.cage.M3L6(
+                building_blocks=(bb1, bb2),
+            ),
+        )
+
+        moldoc_display_molecule = molecule.Molecule(
+            atoms=(
+                molecule.Atom(
+                    atomic_number=atom.get_atomic_number(),
+                    position=position,
+                ) for atom, position in zip(
+                    cage.get_atoms(),
+                    cage.get_position_matrix(),
+                )
+            ),
+            bonds=(
+                molecule.Bond(
+                    atom1_id=bond.get_atom1().get_id(),
+                    atom2_id=bond.get_atom2().get_id(),
+                    order=(
+                        1
+                        if bond.get_order() == 9
+                        else bond.get_order()
+                    ),
+                ) for bond in cage.get_bonds()
+            ),
+        )
+
+    :class:`.MCHammer` optimized construction
+
+    .. moldoc::
+
+        import moldoc.molecule as molecule
+        import stk
+
+        bb1 = stk.BuildingBlock(
+            smiles='[Pd+2]',
+            functional_groups=(
+                stk.SingleAtom(stk.Pd(0, charge=2))
+                for i in range(4)
+            ),
+            position_matrix=[[0, 0, 0]],
+        )
+
+        bb2 = stk.BuildingBlock(
+            smiles=(
+                'C1=NC=CC(C2=CC=CC(C3=C'
+                'C=NC=C3)=C2)=C1'
+            ),
+            functional_groups=[
+                stk.SmartsFunctionalGroupFactory(
+                    smarts='[#6]~[#7X2]~[#6]',
+                    bonders=(1, ),
+                    deleters=(),
+                ),
+            ],
+        )
+
+        cage = stk.ConstructedMolecule(
+            topology_graph=stk.cage.M3L6(
+                building_blocks=(bb1, bb2),
+                optimizer=stk.MCHammer(),
+            ),
+        )
+
+        moldoc_display_molecule = molecule.Molecule(
+            atoms=(
+                molecule.Atom(
+                    atomic_number=atom.get_atomic_number(),
+                    position=position,
+                ) for atom, position in zip(
+                    cage.get_atoms(),
+                    cage.get_position_matrix(),
+                )
+            ),
+            bonds=(
+                molecule.Bond(
+                    atom1_id=bond.get_atom1().get_id(),
+                    atom2_id=bond.get_atom2().get_id(),
+                    order=(
+                        1
+                        if bond.get_order() == 9
+                        else bond.get_order()
+                    ),
+                ) for bond in cage.get_bonds()
+            ),
+        )
+
     Metal building blocks with four functional groups are
     required for this topology.
 

--- a/src/stk/molecular/topology_graphs/cage/metal_topologies/m4l4_square.py
+++ b/src/stk/molecular/topology_graphs/cage/metal_topologies/m4l4_square.py
@@ -14,6 +14,127 @@ class M4L4Square(Cage):
     """
     Represents a cage topology graph.
 
+    Unoptimized construction
+
+    .. moldoc::
+
+        import moldoc.molecule as molecule
+        import stk
+
+        bb1 = stk.BuildingBlock(
+            smiles='[Pd+2]',
+            functional_groups=(
+                stk.SingleAtom(stk.Pd(0, charge=2))
+                for i in range(2)
+            ),
+            position_matrix=[[0, 0, 0]],
+        )
+
+        bb2 = stk.BuildingBlock(
+            smiles=(
+                'C1=NC=CC(C2=CC=CC(C3=C'
+                'C=NC=C3)=C2)=C1'
+            ),
+            functional_groups=[
+                stk.SmartsFunctionalGroupFactory(
+                    smarts='[#6]~[#7X2]~[#6]',
+                    bonders=(1, ),
+                    deleters=(),
+                ),
+            ],
+        )
+
+        cage = stk.ConstructedMolecule(
+            topology_graph=stk.cage.M4L4Square(
+                corners=bb1,
+                linkers=bb2,
+            ),
+        )
+
+        moldoc_display_molecule = molecule.Molecule(
+            atoms=(
+                molecule.Atom(
+                    atomic_number=atom.get_atomic_number(),
+                    position=position,
+                ) for atom, position in zip(
+                    cage.get_atoms(),
+                    cage.get_position_matrix(),
+                )
+            ),
+            bonds=(
+                molecule.Bond(
+                    atom1_id=bond.get_atom1().get_id(),
+                    atom2_id=bond.get_atom2().get_id(),
+                    order=(
+                        1
+                        if bond.get_order() == 9
+                        else bond.get_order()
+                    ),
+                ) for bond in cage.get_bonds()
+            ),
+        )
+
+    :class:`.MCHammer` optimized construction
+
+    .. moldoc::
+
+        import moldoc.molecule as molecule
+        import stk
+
+        bb1 = stk.BuildingBlock(
+            smiles='[Pd+2]',
+            functional_groups=(
+                stk.SingleAtom(stk.Pd(0, charge=2))
+                for i in range(2)
+            ),
+            position_matrix=[[0, 0, 0]],
+        )
+
+        bb2 = stk.BuildingBlock(
+            smiles=(
+                'C1=NC=CC(C2=CC=CC(C3=C'
+                'C=NC=C3)=C2)=C1'
+            ),
+            functional_groups=[
+                stk.SmartsFunctionalGroupFactory(
+                    smarts='[#6]~[#7X2]~[#6]',
+                    bonders=(1, ),
+                    deleters=(),
+                ),
+            ],
+        )
+
+        cage = stk.ConstructedMolecule(
+            topology_graph=stk.cage.M4L4Square(
+                corners=bb1,
+                linkers=bb2,
+                optimizer=stk.MCHammer(),
+            ),
+        )
+
+        moldoc_display_molecule = molecule.Molecule(
+            atoms=(
+                molecule.Atom(
+                    atomic_number=atom.get_atomic_number(),
+                    position=position,
+                ) for atom, position in zip(
+                    cage.get_atoms(),
+                    cage.get_position_matrix(),
+                )
+            ),
+            bonds=(
+                molecule.Bond(
+                    atom1_id=bond.get_atom1().get_id(),
+                    atom2_id=bond.get_atom2().get_id(),
+                    order=(
+                        1
+                        if bond.get_order() == 9
+                        else bond.get_order()
+                    ),
+                ) for bond in cage.get_bonds()
+            ),
+        )
+
     Both `corner` and `linker` vertices require building blocks with
     two functional groups for this topology. This class replaces the
     `building_blocks` parameter with the `corner` and `linker`

--- a/src/stk/molecular/topology_graphs/cage/metal_topologies/m4l4_tetrahedron.py
+++ b/src/stk/molecular/topology_graphs/cage/metal_topologies/m4l4_tetrahedron.py
@@ -15,6 +15,125 @@ class M4L4Tetrahedron(Cage):
     """
     Represents a cage topology graph.
 
+    Unoptimized construction
+
+    .. moldoc::
+
+        import moldoc.molecule as molecule
+        import stk
+
+        bb1 = stk.BuildingBlock(
+            smiles='[Pd+2]',
+            functional_groups=(
+                stk.SingleAtom(stk.Pd(0, charge=2))
+                for i in range(3)
+            ),
+            position_matrix=[[0, 0, 0]],
+        )
+
+        bb2 = stk.BuildingBlock(
+            smiles='c2cnccc2c1cc(c4ccncc4)cc(c3ccncc3)c1',
+            functional_groups=[
+                stk.SmartsFunctionalGroupFactory(
+                    smarts='[#6]~[#7X2]~[#6]',
+                    bonders=(1, ),
+                    deleters=(),
+                ),
+            ],
+        )
+
+        cage = stk.ConstructedMolecule(
+            topology_graph=stk.cage.M4L4Tetrahedron(
+                building_blocks={
+                    bb1: range(4),
+                    bb2: range(4, 8),
+                },
+            ),
+        )
+
+        moldoc_display_molecule = molecule.Molecule(
+            atoms=(
+                molecule.Atom(
+                    atomic_number=atom.get_atomic_number(),
+                    position=position,
+                ) for atom, position in zip(
+                    cage.get_atoms(),
+                    cage.get_position_matrix(),
+                )
+            ),
+            bonds=(
+                molecule.Bond(
+                    atom1_id=bond.get_atom1().get_id(),
+                    atom2_id=bond.get_atom2().get_id(),
+                    order=(
+                        1
+                        if bond.get_order() == 9
+                        else bond.get_order()
+                    ),
+                ) for bond in cage.get_bonds()
+            ),
+        )
+
+    :class:`.MCHammer` optimized construction
+
+    .. moldoc::
+
+        import moldoc.molecule as molecule
+        import stk
+
+        bb1 = stk.BuildingBlock(
+            smiles='[Pd+2]',
+            functional_groups=(
+                stk.SingleAtom(stk.Pd(0, charge=2))
+                for i in range(3)
+            ),
+            position_matrix=[[0, 0, 0]],
+        )
+
+        bb2 = stk.BuildingBlock(
+            smiles='c2cnccc2c1cc(c4ccncc4)cc(c3ccncc3)c1',
+            functional_groups=[
+                stk.SmartsFunctionalGroupFactory(
+                    smarts='[#6]~[#7X2]~[#6]',
+                    bonders=(1, ),
+                    deleters=(),
+                ),
+            ],
+        )
+
+        cage = stk.ConstructedMolecule(
+            topology_graph=stk.cage.M4L4Tetrahedron(
+                building_blocks={
+                    bb1: range(4),
+                    bb2: range(4, 8),
+                },
+                optimizer=stk.MCHammer(),
+            ),
+        )
+
+        moldoc_display_molecule = molecule.Molecule(
+            atoms=(
+                molecule.Atom(
+                    atomic_number=atom.get_atomic_number(),
+                    position=position,
+                ) for atom, position in zip(
+                    cage.get_atoms(),
+                    cage.get_position_matrix(),
+                )
+            ),
+            bonds=(
+                molecule.Bond(
+                    atom1_id=bond.get_atom1().get_id(),
+                    atom2_id=bond.get_atom2().get_id(),
+                    order=(
+                        1
+                        if bond.get_order() == 9
+                        else bond.get_order()
+                    ),
+                ) for bond in cage.get_bonds()
+            ),
+        )
+
     Building blocks with three functional groups are required for this
     topology.
 

--- a/src/stk/molecular/topology_graphs/cage/metal_topologies/m4l6_tetrahedron.py
+++ b/src/stk/molecular/topology_graphs/cage/metal_topologies/m4l6_tetrahedron.py
@@ -15,6 +15,152 @@ class M4L6Tetrahedron(Cage):
     """
     Represents a cage topology graph.
 
+    .. moldoc::
+
+        import moldoc.molecule as molecule
+        import stk
+
+        bb1 = stk.BuildingBlock(
+            smiles='C1=NC(C=NBr)=CC=C1',
+            functional_groups=[
+                stk.SmartsFunctionalGroupFactory(
+                    smarts='[#6]~[#7X2]~[#35]',
+                    bonders=(1, ),
+                    deleters=(),
+                ),
+                stk.SmartsFunctionalGroupFactory(
+                    smarts='[#6]~[#7X2]~[#6]',
+                    bonders=(1, ),
+                    deleters=(),
+                ),
+            ],
+        )
+
+        iron_atom = stk.BuildingBlock(
+            smiles='[Fe+2]',
+            functional_groups=(
+                stk.SingleAtom(stk.Fe(0, charge=2))
+                for i in range(6)
+            ),
+            position_matrix=[[0, 0, 0]],
+        )
+
+        iron_oct_delta = stk.ConstructedMolecule(
+            topology_graph=stk.metal_complex.OctahedralDelta(
+                metals=iron_atom,
+                ligands=bb1,
+            ),
+        )
+
+        iron_oct_delta = stk.BuildingBlock.init_from_molecule(
+            molecule=iron_oct_delta,
+            functional_groups=[stk.BromoFactory()],
+        )
+
+        cage = stk.ConstructedMolecule(
+            topology_graph=stk.cage.M4L6Tetrahedron(
+                building_blocks=(iron_oct_delta, ),
+            ),
+        )
+
+        moldoc_display_molecule = molecule.Molecule(
+            atoms=(
+                molecule.Atom(
+                    atomic_number=atom.get_atomic_number(),
+                    position=position,
+                ) for atom, position in zip(
+                    cage.get_atoms(),
+                    cage.get_position_matrix(),
+                )
+            ),
+            bonds=(
+                molecule.Bond(
+                    atom1_id=bond.get_atom1().get_id(),
+                    atom2_id=bond.get_atom2().get_id(),
+                    order=(
+                        1
+                        if bond.get_order() == 9
+                        else bond.get_order()
+                    ),
+                ) for bond in cage.get_bonds()
+            ),
+        )
+
+    :class:`.MCHammer` optimized construction
+
+    .. moldoc::
+
+        import moldoc.molecule as molecule
+        import stk
+
+        bb1 = stk.BuildingBlock(
+            smiles='C1=NC(C=NBr)=CC=C1',
+            functional_groups=[
+                stk.SmartsFunctionalGroupFactory(
+                    smarts='[#6]~[#7X2]~[#35]',
+                    bonders=(1, ),
+                    deleters=(),
+                ),
+                stk.SmartsFunctionalGroupFactory(
+                    smarts='[#6]~[#7X2]~[#6]',
+                    bonders=(1, ),
+                    deleters=(),
+                ),
+            ],
+        )
+
+        iron_atom = stk.BuildingBlock(
+            smiles='[Fe+2]',
+            functional_groups=(
+                stk.SingleAtom(stk.Fe(0, charge=2))
+                for i in range(6)
+            ),
+            position_matrix=[[0, 0, 0]],
+        )
+
+        iron_oct_delta = stk.ConstructedMolecule(
+            topology_graph=stk.metal_complex.OctahedralDelta(
+                metals=iron_atom,
+                ligands=bb1,
+                optimizer=stk.MCHammer(),
+            ),
+        )
+
+        iron_oct_delta = stk.BuildingBlock.init_from_molecule(
+            molecule=iron_oct_delta,
+            functional_groups=[stk.BromoFactory()],
+        )
+
+        cage = stk.ConstructedMolecule(
+            topology_graph=stk.cage.M4L6Tetrahedron(
+                building_blocks=(iron_oct_delta, ),
+                optimizer=stk.MCHammer(),
+            ),
+        )
+
+        moldoc_display_molecule = molecule.Molecule(
+            atoms=(
+                molecule.Atom(
+                    atomic_number=atom.get_atomic_number(),
+                    position=position,
+                ) for atom, position in zip(
+                    cage.get_atoms(),
+                    cage.get_position_matrix(),
+                )
+            ),
+            bonds=(
+                molecule.Bond(
+                    atom1_id=bond.get_atom1().get_id(),
+                    atom2_id=bond.get_atom2().get_id(),
+                    order=(
+                        1
+                        if bond.get_order() == 9
+                        else bond.get_order()
+                    ),
+                ) for bond in cage.get_bonds()
+            ),
+        )
+
     This topology directly connects the vertices of the tetrahedron.
 
     Building blocks with three functional groups are required for this
@@ -62,7 +208,7 @@ class M4L6Tetrahedron(Cage):
                     bonders=(1, ),
                     deleters=(),
                 ),
-            ]
+            ],
         )
 
     We then build the desired metal complex with this linker. This
@@ -83,10 +229,10 @@ class M4L6Tetrahedron(Cage):
 
         # Build iron complex with delta stereochemistry.
         iron_oct_delta = stk.ConstructedMolecule(
-            stk.metal_complex.OctahedralDelta(
+            topology_graph=stk.metal_complex.OctahedralDelta(
                 metals=iron_atom,
                 ligands=bb1,
-            )
+            ),
         )
 
     We then redefine the metal complex building block based on its
@@ -98,7 +244,7 @@ class M4L6Tetrahedron(Cage):
         # Assign Bromo functional groups to the metal complex.
         iron_oct_delta = stk.BuildingBlock.init_from_molecule(
             molecule=iron_oct_delta,
-            functional_groups=[stk.BromoFactory()]
+            functional_groups=[stk.BromoFactory()],
         )
 
     Finally, we build the :class:`M4L6Tetrahedron` cage using this
@@ -108,9 +254,9 @@ class M4L6Tetrahedron(Cage):
 
         # Build an M4L6 Tetrahedron.
         cage2 = stk.ConstructedMolecule(
-            stk.cage.M4L6Tetrahedron(
+            topology_graph=stk.cage.M4L6Tetrahedron(
                 building_blocks=(iron_oct_delta, ),
-            )
+            ),
         )
 
     Importantly, in the case that the linker cannot be disconnected

--- a/src/stk/molecular/topology_graphs/cage/metal_topologies/m4l6_tetrahedron_spacer.py
+++ b/src/stk/molecular/topology_graphs/cage/metal_topologies/m4l6_tetrahedron_spacer.py
@@ -15,6 +15,125 @@ class M4L6TetrahedronSpacer(Cage):
     """
     Represents a cage topology graph.
 
+    Unoptimized construction
+
+    .. moldoc::
+
+        import moldoc.molecule as molecule
+        import stk
+
+        bb1 = stk.BuildingBlock(
+            smiles='[Pd+2]',
+            functional_groups=(
+                stk.SingleAtom(stk.Pd(0, charge=2))
+                for i in range(3)
+            ),
+            position_matrix=[[0, 0, 0]],
+        )
+
+        bb2 = stk.BuildingBlock(
+            smiles=(
+                'C1=NC=CC(C2=CC=CC(C3=C'
+                'C=NC=C3)=C2)=C1'
+            ),
+            functional_groups=[
+                stk.SmartsFunctionalGroupFactory(
+                    smarts='[#6]~[#7X2]~[#6]',
+                    bonders=(1, ),
+                    deleters=(),
+                ),
+            ],
+        )
+
+        cage = stk.ConstructedMolecule(
+            topology_graph=stk.cage.M4L6TetrahedronSpacer(
+                building_blocks=(bb1, bb2),
+            ),
+        )
+
+        moldoc_display_molecule = molecule.Molecule(
+            atoms=(
+                molecule.Atom(
+                    atomic_number=atom.get_atomic_number(),
+                    position=position,
+                ) for atom, position in zip(
+                    cage.get_atoms(),
+                    cage.get_position_matrix(),
+                )
+            ),
+            bonds=(
+                molecule.Bond(
+                    atom1_id=bond.get_atom1().get_id(),
+                    atom2_id=bond.get_atom2().get_id(),
+                    order=(
+                        1
+                        if bond.get_order() == 9
+                        else bond.get_order()
+                    ),
+                ) for bond in cage.get_bonds()
+            ),
+        )
+
+    :class:`.MCHammer` optimized construction
+
+    .. moldoc::
+
+        import moldoc.molecule as molecule
+        import stk
+
+        bb1 = stk.BuildingBlock(
+            smiles='[Pd+2]',
+            functional_groups=(
+                stk.SingleAtom(stk.Pd(0, charge=2))
+                for i in range(3)
+            ),
+            position_matrix=[[0, 0, 0]],
+        )
+
+        bb2 = stk.BuildingBlock(
+            smiles=(
+                'C1=NC=CC(C2=CC=CC(C3=C'
+                'C=NC=C3)=C2)=C1'
+            ),
+            functional_groups=[
+                stk.SmartsFunctionalGroupFactory(
+                    smarts='[#6]~[#7X2]~[#6]',
+                    bonders=(1, ),
+                    deleters=(),
+                ),
+            ],
+        )
+
+        cage = stk.ConstructedMolecule(
+            topology_graph=stk.cage.M4L6TetrahedronSpacer(
+                building_blocks=(bb1, bb2),
+                optimizer=stk.MCHammer(),
+            ),
+        )
+
+        moldoc_display_molecule = molecule.Molecule(
+            atoms=(
+                molecule.Atom(
+                    atomic_number=atom.get_atomic_number(),
+                    position=position,
+                ) for atom, position in zip(
+                    cage.get_atoms(),
+                    cage.get_position_matrix(),
+                )
+            ),
+            bonds=(
+                molecule.Bond(
+                    atom1_id=bond.get_atom1().get_id(),
+                    atom2_id=bond.get_atom2().get_id(),
+                    order=(
+                        1
+                        if bond.get_order() == 9
+                        else bond.get_order()
+                    ),
+                ) for bond in cage.get_bonds()
+            ),
+        )
+
     This topology places a ditopic spacer between the vertices of the
     tetrahedron.
 

--- a/src/stk/molecular/topology_graphs/cage/metal_topologies/m4l8.py
+++ b/src/stk/molecular/topology_graphs/cage/metal_topologies/m4l8.py
@@ -13,6 +13,125 @@ class M4L8(Cage):
     """
     Represents a cage topology graph.
 
+    Unoptimized construction
+
+    .. moldoc::
+
+        import moldoc.molecule as molecule
+        import stk
+
+        bb1 = stk.BuildingBlock(
+            smiles='[Pd+2]',
+            functional_groups=(
+                stk.SingleAtom(stk.Pd(0, charge=2))
+                for i in range(4)
+            ),
+            position_matrix=[[0, 0, 0]],
+        )
+
+        bb2 = stk.BuildingBlock(
+            smiles=(
+                'C1=NC=CC(C2=CC=CC(C3=C'
+                'C=NC=C3)=C2)=C1'
+            ),
+            functional_groups=[
+                stk.SmartsFunctionalGroupFactory(
+                    smarts='[#6]~[#7X2]~[#6]',
+                    bonders=(1, ),
+                    deleters=(),
+                ),
+            ],
+        )
+
+        cage = stk.ConstructedMolecule(
+            topology_graph=stk.cage.M4L8(
+                building_blocks=(bb1, bb2),
+            ),
+        )
+
+        moldoc_display_molecule = molecule.Molecule(
+            atoms=(
+                molecule.Atom(
+                    atomic_number=atom.get_atomic_number(),
+                    position=position,
+                ) for atom, position in zip(
+                    cage.get_atoms(),
+                    cage.get_position_matrix(),
+                )
+            ),
+            bonds=(
+                molecule.Bond(
+                    atom1_id=bond.get_atom1().get_id(),
+                    atom2_id=bond.get_atom2().get_id(),
+                    order=(
+                        1
+                        if bond.get_order() == 9
+                        else bond.get_order()
+                    ),
+                ) for bond in cage.get_bonds()
+            ),
+        )
+
+    :class:`.MCHammer` optimized construction
+
+    .. moldoc::
+
+        import moldoc.molecule as molecule
+        import stk
+
+        bb1 = stk.BuildingBlock(
+            smiles='[Pd+2]',
+            functional_groups=(
+                stk.SingleAtom(stk.Pd(0, charge=2))
+                for i in range(4)
+            ),
+            position_matrix=[[0, 0, 0]],
+        )
+
+        bb2 = stk.BuildingBlock(
+            smiles=(
+                'C1=NC=CC(C2=CC=CC(C3=C'
+                'C=NC=C3)=C2)=C1'
+            ),
+            functional_groups=[
+                stk.SmartsFunctionalGroupFactory(
+                    smarts='[#6]~[#7X2]~[#6]',
+                    bonders=(1, ),
+                    deleters=(),
+                ),
+            ],
+        )
+
+        cage = stk.ConstructedMolecule(
+            topology_graph=stk.cage.M4L8(
+                building_blocks=(bb1, bb2),
+                optimizer=stk.MCHammer(),
+            ),
+        )
+
+        moldoc_display_molecule = molecule.Molecule(
+            atoms=(
+                molecule.Atom(
+                    atomic_number=atom.get_atomic_number(),
+                    position=position,
+                ) for atom, position in zip(
+                    cage.get_atoms(),
+                    cage.get_position_matrix(),
+                )
+            ),
+            bonds=(
+                molecule.Bond(
+                    atom1_id=bond.get_atom1().get_id(),
+                    atom2_id=bond.get_atom2().get_id(),
+                    order=(
+                        1
+                        if bond.get_order() == 9
+                        else bond.get_order()
+                    ),
+                ) for bond in cage.get_bonds()
+            ),
+        )
+
     Metal building blocks with four functional groups are
     required for this topology.
 

--- a/src/stk/molecular/topology_graphs/cage/metal_topologies/m6l12_cube.py
+++ b/src/stk/molecular/topology_graphs/cage/metal_topologies/m6l12_cube.py
@@ -15,6 +15,125 @@ class M6L12Cube(Cage):
     """
     Represents a cage topology graph.
 
+    Unoptimized construction
+
+    .. moldoc::
+
+        import moldoc.molecule as molecule
+        import stk
+
+        bb1 = stk.BuildingBlock(
+            smiles='[Pd+2]',
+            functional_groups=(
+                stk.SingleAtom(stk.Pd(0, charge=2))
+                for i in range(4)
+            ),
+            position_matrix=[[0, 0, 0]],
+        )
+
+        bb2 = stk.BuildingBlock(
+            smiles=(
+                'C1=NC=CC(C2=CC=CC(C3=C'
+                'C=NC=C3)=C2)=C1'
+            ),
+            functional_groups=[
+                stk.SmartsFunctionalGroupFactory(
+                    smarts='[#6]~[#7X2]~[#6]',
+                    bonders=(1, ),
+                    deleters=(),
+                ),
+            ],
+        )
+
+        cage = stk.ConstructedMolecule(
+            topology_graph=stk.cage.M6L12Cube(
+                building_blocks=(bb1, bb2),
+            ),
+        )
+
+        moldoc_display_molecule = molecule.Molecule(
+            atoms=(
+                molecule.Atom(
+                    atomic_number=atom.get_atomic_number(),
+                    position=position,
+                ) for atom, position in zip(
+                    cage.get_atoms(),
+                    cage.get_position_matrix(),
+                )
+            ),
+            bonds=(
+                molecule.Bond(
+                    atom1_id=bond.get_atom1().get_id(),
+                    atom2_id=bond.get_atom2().get_id(),
+                    order=(
+                        1
+                        if bond.get_order() == 9
+                        else bond.get_order()
+                    ),
+                ) for bond in cage.get_bonds()
+            ),
+        )
+
+    :class:`.Collapser` optimized construction
+
+    .. moldoc::
+
+        import moldoc.molecule as molecule
+        import stk
+
+        bb1 = stk.BuildingBlock(
+            smiles='[Pd+2]',
+            functional_groups=(
+                stk.SingleAtom(stk.Pd(0, charge=2))
+                for i in range(4)
+            ),
+            position_matrix=[[0, 0, 0]],
+        )
+
+        bb2 = stk.BuildingBlock(
+            smiles=(
+                'C1=NC=CC(C2=CC=CC(C3=C'
+                'C=NC=C3)=C2)=C1'
+            ),
+            functional_groups=[
+                stk.SmartsFunctionalGroupFactory(
+                    smarts='[#6]~[#7X2]~[#6]',
+                    bonders=(1, ),
+                    deleters=(),
+                ),
+            ],
+        )
+
+        cage = stk.ConstructedMolecule(
+            topology_graph=stk.cage.M6L12Cube(
+                building_blocks=(bb1, bb2),
+                optimizer=stk.Collapser(),
+            ),
+        )
+
+        moldoc_display_molecule = molecule.Molecule(
+            atoms=(
+                molecule.Atom(
+                    atomic_number=atom.get_atomic_number(),
+                    position=position,
+                ) for atom, position in zip(
+                    cage.get_atoms(),
+                    cage.get_position_matrix(),
+                )
+            ),
+            bonds=(
+                molecule.Bond(
+                    atom1_id=bond.get_atom1().get_id(),
+                    atom2_id=bond.get_atom2().get_id(),
+                    order=(
+                        1
+                        if bond.get_order() == 9
+                        else bond.get_order()
+                    ),
+                ) for bond in cage.get_bonds()
+            ),
+        )
+
     Metal building blocks with four functional groups are
     required for this topology.
 

--- a/src/stk/molecular/topology_graphs/cage/metal_topologies/m6l2l3_prism.py
+++ b/src/stk/molecular/topology_graphs/cage/metal_topologies/m6l2l3_prism.py
@@ -15,6 +15,155 @@ class M6L2L3Prism(Cage):
     """
     Represents a cage topology graph.
 
+    Unoptimized construction
+
+    .. moldoc::
+
+        import moldoc.molecule as molecule
+        import stk
+
+        bb1 = stk.BuildingBlock(
+            smiles='[Pd+2]',
+            functional_groups=(
+                stk.SingleAtom(stk.Pd(0, charge=2))
+                for i in range(3)
+            ),
+            position_matrix=[[0, 0, 0]],
+        )
+
+        bb2 = stk.BuildingBlock(
+            smiles='c2cnccc2c1cc(c4ccncc4)cc(c3ccncc3)c1',
+            functional_groups=[
+                stk.SmartsFunctionalGroupFactory(
+                    smarts='[#6]~[#7X2]~[#6]',
+                    bonders=(1, ),
+                    deleters=(),
+                ),
+            ],
+        )
+
+        bb3 = stk.BuildingBlock(
+            smiles=(
+                'c2cnccc2C#Cc1c(C#Cc4ccncc4)cc'
+                '(C#Cc3ccncc3)c(C#Cc5ccncc5)c1'
+            ),
+            functional_groups=[
+                stk.SmartsFunctionalGroupFactory(
+                    smarts='[#6]~[#7X2]~[#6]',
+                    bonders=(1, ),
+                    deleters=(),
+                ),
+            ],
+        )
+
+        cage = stk.ConstructedMolecule(
+            topology_graph=stk.cage.M6L2L3Prism(
+                building_blocks={
+                    bb1: range(6),
+                    bb2: (6, 7),
+                    bb3: range(8, 11),
+                },
+            ),
+        )
+
+        moldoc_display_molecule = molecule.Molecule(
+            atoms=(
+                molecule.Atom(
+                    atomic_number=atom.get_atomic_number(),
+                    position=position,
+                ) for atom, position in zip(
+                    cage.get_atoms(),
+                    cage.get_position_matrix(),
+                )
+            ),
+            bonds=(
+                molecule.Bond(
+                    atom1_id=bond.get_atom1().get_id(),
+                    atom2_id=bond.get_atom2().get_id(),
+                    order=(
+                        1
+                        if bond.get_order() == 9
+                        else bond.get_order()
+                    ),
+                ) for bond in cage.get_bonds()
+            ),
+        )
+
+    :class:`.Collapser` optimized construction
+
+    .. moldoc::
+
+        import moldoc.molecule as molecule
+        import stk
+
+        bb1 = stk.BuildingBlock(
+            smiles='[Pd+2]',
+            functional_groups=(
+                stk.SingleAtom(stk.Pd(0, charge=2))
+                for i in range(3)
+            ),
+            position_matrix=[[0, 0, 0]],
+        )
+
+        bb2 = stk.BuildingBlock(
+            smiles='c2cnccc2c1cc(c4ccncc4)cc(c3ccncc3)c1',
+            functional_groups=[
+                stk.SmartsFunctionalGroupFactory(
+                    smarts='[#6]~[#7X2]~[#6]',
+                    bonders=(1, ),
+                    deleters=(),
+                ),
+            ],
+        )
+
+        bb3 = stk.BuildingBlock(
+            smiles=(
+                'c2cnccc2C#Cc1c(C#Cc4ccncc4)cc'
+                '(C#Cc3ccncc3)c(C#Cc5ccncc5)c1'
+            ),
+            functional_groups=[
+                stk.SmartsFunctionalGroupFactory(
+                    smarts='[#6]~[#7X2]~[#6]',
+                    bonders=(1, ),
+                    deleters=(),
+                ),
+            ],
+        )
+
+        cage = stk.ConstructedMolecule(
+            topology_graph=stk.cage.M6L2L3Prism(
+                building_blocks={
+                    bb1: range(6),
+                    bb2: (6, 7),
+                    bb3: range(8, 11),
+                },
+                optimizer=stk.Collapser(),
+            ),
+        )
+
+        moldoc_display_molecule = molecule.Molecule(
+            atoms=(
+                molecule.Atom(
+                    atomic_number=atom.get_atomic_number(),
+                    position=position,
+                ) for atom, position in zip(
+                    cage.get_atoms(),
+                    cage.get_position_matrix(),
+                )
+            ),
+            bonds=(
+                molecule.Bond(
+                    atom1_id=bond.get_atom1().get_id(),
+                    atom2_id=bond.get_atom2().get_id(),
+                    order=(
+                        1
+                        if bond.get_order() == 9
+                        else bond.get_order()
+                    ),
+                ) for bond in cage.get_bonds()
+            ),
+        )
+
     Metal building blocks with three functional groups are
     required for this topology.
 

--- a/src/stk/molecular/topology_graphs/cage/metal_topologies/m8l6_cube.py
+++ b/src/stk/molecular/topology_graphs/cage/metal_topologies/m8l6_cube.py
@@ -13,6 +13,125 @@ class M8L6Cube(Cage):
     """
     Represents a cage topology graph.
 
+    Unoptimized construction
+
+    .. moldoc::
+
+        import moldoc.molecule as molecule
+        import stk
+
+        bb1 = stk.BuildingBlock(
+            smiles='[Pd+2]',
+            functional_groups=(
+                stk.SingleAtom(stk.Pd(0, charge=2))
+                for i in range(3)
+            ),
+            position_matrix=[[0, 0, 0]],
+        )
+
+        bb2 = stk.BuildingBlock(
+            smiles=(
+                'c2cnccc2C#Cc1c(C#Cc4ccncc4)cc'
+                '(C#Cc3ccncc3)c(C#Cc5ccncc5)c1'
+            ),
+            functional_groups=[
+                stk.SmartsFunctionalGroupFactory(
+                    smarts='[#6]~[#7X2]~[#6]',
+                    bonders=(1, ),
+                    deleters=(),
+                ),
+            ],
+        )
+
+        cage = stk.ConstructedMolecule(
+            topology_graph=stk.cage.M8L6Cube(
+                building_blocks=(bb1, bb2),
+            ),
+        )
+
+        moldoc_display_molecule = molecule.Molecule(
+            atoms=(
+                molecule.Atom(
+                    atomic_number=atom.get_atomic_number(),
+                    position=position,
+                ) for atom, position in zip(
+                    cage.get_atoms(),
+                    cage.get_position_matrix(),
+                )
+            ),
+            bonds=(
+                molecule.Bond(
+                    atom1_id=bond.get_atom1().get_id(),
+                    atom2_id=bond.get_atom2().get_id(),
+                    order=(
+                        1
+                        if bond.get_order() == 9
+                        else bond.get_order()
+                    ),
+                ) for bond in cage.get_bonds()
+            ),
+        )
+
+    :class:`.MCHammer` optimized construction
+
+    .. moldoc::
+
+        import moldoc.molecule as molecule
+        import stk
+
+        bb1 = stk.BuildingBlock(
+            smiles='[Pd+2]',
+            functional_groups=(
+                stk.SingleAtom(stk.Pd(0, charge=2))
+                for i in range(3)
+            ),
+            position_matrix=[[0, 0, 0]],
+        )
+
+        bb2 = stk.BuildingBlock(
+            smiles=(
+                'c2cnccc2C#Cc1c(C#Cc4ccncc4)cc'
+                '(C#Cc3ccncc3)c(C#Cc5ccncc5)c1'
+            ),
+            functional_groups=[
+                stk.SmartsFunctionalGroupFactory(
+                    smarts='[#6]~[#7X2]~[#6]',
+                    bonders=(1, ),
+                    deleters=(),
+                ),
+            ],
+        )
+
+        cage = stk.ConstructedMolecule(
+            topology_graph=stk.cage.M8L6Cube(
+                building_blocks=(bb1, bb2),
+                optimizer=stk.MCHammer(),
+            ),
+        )
+
+        moldoc_display_molecule = molecule.Molecule(
+            atoms=(
+                molecule.Atom(
+                    atomic_number=atom.get_atomic_number(),
+                    position=position,
+                ) for atom, position in zip(
+                    cage.get_atoms(),
+                    cage.get_position_matrix(),
+                )
+            ),
+            bonds=(
+                molecule.Bond(
+                    atom1_id=bond.get_atom1().get_id(),
+                    atom2_id=bond.get_atom2().get_id(),
+                    order=(
+                        1
+                        if bond.get_order() == 9
+                        else bond.get_order()
+                    ),
+                ) for bond in cage.get_bonds()
+            ),
+        )
+
     Metal building blocks with three functional groups are
     required for this topology.
 

--- a/src/stk/molecular/topology_graphs/cage/three_plus_four/six_plus_eight.py
+++ b/src/stk/molecular/topology_graphs/cage/three_plus_four/six_plus_eight.py
@@ -13,6 +13,42 @@ class SixPlusEight(Cage):
     """
     Represents a cage topology graph.
 
+    .. moldoc::
+
+        import moldoc.molecule as molecule
+        import stk
+
+        bb1 = stk.BuildingBlock(
+            smiles='Brc1c(Br)cc(Br)c(Br)c1',
+            functional_groups=[stk.BromoFactory()],
+        )
+        bb2 = stk.BuildingBlock(
+            smiles='Brc1cc(Br)cc(Br)c1',
+            functional_groups=[stk.BromoFactory()],
+        )
+        cage = stk.ConstructedMolecule(
+            topology_graph=stk.cage.SixPlusEight((bb1, bb2)),
+        )
+
+        moldoc_display_molecule = molecule.Molecule(
+            atoms=(
+                molecule.Atom(
+                    atomic_number=atom.get_atomic_number(),
+                    position=position,
+                ) for atom, position in zip(
+                    cage.get_atoms(),
+                    cage.get_position_matrix(),
+                )
+            ),
+            bonds=(
+                molecule.Bond(
+                    atom1_id=bond.get_atom1().get_id(),
+                    atom2_id=bond.get_atom2().get_id(),
+                    order=bond.get_order(),
+                ) for bond in cage.get_bonds()
+            ),
+        )
+
     Building blocks with three and four functional groups are required
     for this topology graph.
 

--- a/src/stk/molecular/topology_graphs/cage/three_plus_four/six_plus_eight.py
+++ b/src/stk/molecular/topology_graphs/cage/three_plus_four/six_plus_eight.py
@@ -13,6 +13,8 @@ class SixPlusEight(Cage):
     """
     Represents a cage topology graph.
 
+    Unoptimized construction
+
     .. moldoc::
 
         import moldoc.molecule as molecule
@@ -28,6 +30,47 @@ class SixPlusEight(Cage):
         )
         cage = stk.ConstructedMolecule(
             topology_graph=stk.cage.SixPlusEight((bb1, bb2)),
+        )
+
+        moldoc_display_molecule = molecule.Molecule(
+            atoms=(
+                molecule.Atom(
+                    atomic_number=atom.get_atomic_number(),
+                    position=position,
+                ) for atom, position in zip(
+                    cage.get_atoms(),
+                    cage.get_position_matrix(),
+                )
+            ),
+            bonds=(
+                molecule.Bond(
+                    atom1_id=bond.get_atom1().get_id(),
+                    atom2_id=bond.get_atom2().get_id(),
+                    order=bond.get_order(),
+                ) for bond in cage.get_bonds()
+            ),
+        )
+
+    :class:`.MCHammer` optimized consturction
+
+    .. moldoc::
+
+        import moldoc.molecule as molecule
+        import stk
+
+        bb1 = stk.BuildingBlock(
+            smiles='Brc1c(Br)cc(Br)c(Br)c1',
+            functional_groups=[stk.BromoFactory()],
+        )
+        bb2 = stk.BuildingBlock(
+            smiles='Brc1cc(Br)cc(Br)c1',
+            functional_groups=[stk.BromoFactory()],
+        )
+        cage = stk.ConstructedMolecule(
+            topology_graph=stk.cage.SixPlusEight(
+                building_blocks=(bb1, bb2),
+                optimizer=stk.MCHammer(),
+            ),
         )
 
         moldoc_display_molecule = molecule.Molecule(

--- a/src/stk/molecular/topology_graphs/cage/three_plus_three/four_plus_four.py
+++ b/src/stk/molecular/topology_graphs/cage/three_plus_three/four_plus_four.py
@@ -13,6 +13,38 @@ class FourPlusFour(Cage):
     """
     Represents a cube cage topology graph.
 
+    .. moldoc::
+
+        import moldoc.molecule as molecule
+        import stk
+
+        bb = stk.BuildingBlock(
+            smiles='Brc1cc(Br)cc(Br)c1',
+            functional_groups=[stk.BromoFactory()],
+        )
+        cage = stk.ConstructedMolecule(
+            topology_graph=stk.cage.FourPlusFour((bb, )),
+        )
+
+        moldoc_display_molecule = molecule.Molecule(
+            atoms=(
+                molecule.Atom(
+                    atomic_number=atom.get_atomic_number(),
+                    position=position,
+                ) for atom, position in zip(
+                    cage.get_atoms(),
+                    cage.get_position_matrix(),
+                )
+            ),
+            bonds=(
+                molecule.Bond(
+                    atom1_id=bond.get_atom1().get_id(),
+                    atom2_id=bond.get_atom2().get_id(),
+                    order=bond.get_order(),
+                ) for bond in cage.get_bonds()
+            ),
+        )
+
     Building blocks with three functional groups are required for
     this topology.
 

--- a/src/stk/molecular/topology_graphs/cage/three_plus_three/four_plus_four.py
+++ b/src/stk/molecular/topology_graphs/cage/three_plus_three/four_plus_four.py
@@ -13,6 +13,8 @@ class FourPlusFour(Cage):
     """
     Represents a cube cage topology graph.
 
+    Unoptimized construction
+
     .. moldoc::
 
         import moldoc.molecule as molecule
@@ -24,6 +26,43 @@ class FourPlusFour(Cage):
         )
         cage = stk.ConstructedMolecule(
             topology_graph=stk.cage.FourPlusFour((bb, )),
+        )
+
+        moldoc_display_molecule = molecule.Molecule(
+            atoms=(
+                molecule.Atom(
+                    atomic_number=atom.get_atomic_number(),
+                    position=position,
+                ) for atom, position in zip(
+                    cage.get_atoms(),
+                    cage.get_position_matrix(),
+                )
+            ),
+            bonds=(
+                molecule.Bond(
+                    atom1_id=bond.get_atom1().get_id(),
+                    atom2_id=bond.get_atom2().get_id(),
+                    order=bond.get_order(),
+                ) for bond in cage.get_bonds()
+            ),
+        )
+
+    :class:`.MCHammer` optimized construction
+
+    .. moldoc::
+
+        import moldoc.molecule as molecule
+        import stk
+
+        bb = stk.BuildingBlock(
+            smiles='Brc1cc(Br)cc(Br)c1',
+            functional_groups=[stk.BromoFactory()],
+        )
+        cage = stk.ConstructedMolecule(
+            topology_graph=stk.cage.FourPlusFour(
+                building_blocks=(bb, ),
+                optimizer=stk.MCHammer(),
+            ),
         )
 
         moldoc_display_molecule = molecule.Molecule(

--- a/src/stk/molecular/topology_graphs/cage/three_plus_three/one_plus_one.py
+++ b/src/stk/molecular/topology_graphs/cage/three_plus_three/one_plus_one.py
@@ -80,6 +80,8 @@ class OnePlusOne(Cage):
     """
     Represents a capsule cage topology graph.
 
+    Unoptimized construction
+
     .. moldoc::
 
         import moldoc.molecule as molecule
@@ -95,6 +97,47 @@ class OnePlusOne(Cage):
         )
         cage = stk.ConstructedMolecule(
             topology_graph=stk.cage.OnePlusOne({bb1: 0, bb2: 1}),
+        )
+
+        moldoc_display_molecule = molecule.Molecule(
+            atoms=(
+                molecule.Atom(
+                    atomic_number=atom.get_atomic_number(),
+                    position=position,
+                ) for atom, position in zip(
+                    cage.get_atoms(),
+                    cage.get_position_matrix(),
+                )
+            ),
+            bonds=(
+                molecule.Bond(
+                    atom1_id=bond.get_atom1().get_id(),
+                    atom2_id=bond.get_atom2().get_id(),
+                    order=bond.get_order(),
+                ) for bond in cage.get_bonds()
+            ),
+        )
+
+    :class:`.Collapser` optimized construction
+
+    .. moldoc::
+
+        import moldoc.molecule as molecule
+        import stk
+
+        bb1 = stk.BuildingBlock(
+            smiles='BrCC(CBr)CBr',
+            functional_groups=[stk.BromoFactory()],
+        )
+        bb2 = stk.BuildingBlock(
+            smiles='Brc1cc(Br)cc(Br)c1',
+            functional_groups=[stk.BromoFactory()],
+        )
+        cage = stk.ConstructedMolecule(
+            topology_graph=stk.cage.OnePlusOne(
+                building_blocks={bb1: 0, bb2: 1},
+                optimizer=stk.MCHammer(),
+            ),
         )
 
         moldoc_display_molecule = molecule.Molecule(

--- a/src/stk/molecular/topology_graphs/cage/three_plus_three/one_plus_one.py
+++ b/src/stk/molecular/topology_graphs/cage/three_plus_three/one_plus_one.py
@@ -80,6 +80,42 @@ class OnePlusOne(Cage):
     """
     Represents a capsule cage topology graph.
 
+    .. moldoc::
+
+        import moldoc.molecule as molecule
+        import stk
+
+        bb1 = stk.BuildingBlock(
+            smiles='BrCC(CBr)CBr',
+            functional_groups=[stk.BromoFactory()],
+        )
+        bb2 = stk.BuildingBlock(
+            smiles='Brc1cc(Br)cc(Br)c1',
+            functional_groups=[stk.BromoFactory()],
+        )
+        cage = stk.ConstructedMolecule(
+            topology_graph=stk.cage.OnePlusOne({bb1: 0, bb2: 1}),
+        )
+
+        moldoc_display_molecule = molecule.Molecule(
+            atoms=(
+                molecule.Atom(
+                    atomic_number=atom.get_atomic_number(),
+                    position=position,
+                ) for atom, position in zip(
+                    cage.get_atoms(),
+                    cage.get_position_matrix(),
+                )
+            ),
+            bonds=(
+                molecule.Bond(
+                    atom1_id=bond.get_atom1().get_id(),
+                    atom2_id=bond.get_atom2().get_id(),
+                    order=bond.get_order(),
+                ) for bond in cage.get_bonds()
+            ),
+        )
+
     Building blocks with three functional groups are required for
     this topology.
 

--- a/src/stk/molecular/topology_graphs/cage/three_plus_three/two_plus_two.py
+++ b/src/stk/molecular/topology_graphs/cage/three_plus_three/two_plus_two.py
@@ -15,6 +15,8 @@ class TwoPlusTwo(Cage):
     """
     Represents a tetrahedron cage topology graph.
 
+    Unoptimized construction
+
     .. moldoc::
 
         import moldoc.molecule as molecule
@@ -26,6 +28,43 @@ class TwoPlusTwo(Cage):
         )
         cage = stk.ConstructedMolecule(
             topology_graph=stk.cage.TwoPlusTwo((bb, )),
+        )
+
+        moldoc_display_molecule = molecule.Molecule(
+            atoms=(
+                molecule.Atom(
+                    atomic_number=atom.get_atomic_number(),
+                    position=position,
+                ) for atom, position in zip(
+                    cage.get_atoms(),
+                    cage.get_position_matrix(),
+                )
+            ),
+            bonds=(
+                molecule.Bond(
+                    atom1_id=bond.get_atom1().get_id(),
+                    atom2_id=bond.get_atom2().get_id(),
+                    order=bond.get_order(),
+                ) for bond in cage.get_bonds()
+            ),
+        )
+
+    :class:`.MCHammer` optimized construction
+
+    .. moldoc::
+
+        import moldoc.molecule as molecule
+        import stk
+
+        bb = stk.BuildingBlock(
+            smiles='Brc1cc(Br)cc(Br)c1',
+            functional_groups=[stk.BromoFactory()],
+        )
+        cage = stk.ConstructedMolecule(
+            topology_graph=stk.cage.TwoPlusTwo(
+                building_blocks=(bb, ),
+                optimizer=stk.MCHammer(),
+            ),
         )
 
         moldoc_display_molecule = molecule.Molecule(

--- a/src/stk/molecular/topology_graphs/cage/three_plus_three/two_plus_two.py
+++ b/src/stk/molecular/topology_graphs/cage/three_plus_three/two_plus_two.py
@@ -15,6 +15,38 @@ class TwoPlusTwo(Cage):
     """
     Represents a tetrahedron cage topology graph.
 
+    .. moldoc::
+
+        import moldoc.molecule as molecule
+        import stk
+
+        bb = stk.BuildingBlock(
+            smiles='Brc1cc(Br)cc(Br)c1',
+            functional_groups=[stk.BromoFactory()],
+        )
+        cage = stk.ConstructedMolecule(
+            topology_graph=stk.cage.TwoPlusTwo((bb, )),
+        )
+
+        moldoc_display_molecule = molecule.Molecule(
+            atoms=(
+                molecule.Atom(
+                    atomic_number=atom.get_atomic_number(),
+                    position=position,
+                ) for atom, position in zip(
+                    cage.get_atoms(),
+                    cage.get_position_matrix(),
+                )
+            ),
+            bonds=(
+                molecule.Bond(
+                    atom1_id=bond.get_atom1().get_id(),
+                    atom2_id=bond.get_atom2().get_id(),
+                    order=bond.get_order(),
+                ) for bond in cage.get_bonds()
+            ),
+        )
+
     Building blocks with three functional groups are required for
     this topology.
 

--- a/src/stk/molecular/topology_graphs/cage/two_plus_five/twelve_plus_thirty.py
+++ b/src/stk/molecular/topology_graphs/cage/two_plus_five/twelve_plus_thirty.py
@@ -15,6 +15,42 @@ class TwelvePlusThirty(Cage):
     """
     Represents a icosahedron cage topology graph.
 
+    .. moldoc::
+
+        import moldoc.molecule as molecule
+        import stk
+
+        bb1 = stk.BuildingBlock(
+            smiles='BrCCBr',
+            functional_groups=[stk.BromoFactory()],
+        )
+        bb2 = stk.BuildingBlock(
+            smiles='BrC1C(Br)C(Br)C(Br)C1Br',
+            functional_groups=[stk.BromoFactory()],
+        )
+        cage = stk.ConstructedMolecule(
+            topology_graph=stk.cage.TwelvePlusThirty((bb1, bb2)),
+        )
+
+        moldoc_display_molecule = molecule.Molecule(
+            atoms=(
+                molecule.Atom(
+                    atomic_number=atom.get_atomic_number(),
+                    position=position,
+                ) for atom, position in zip(
+                    cage.get_atoms(),
+                    cage.get_position_matrix(),
+                )
+            ),
+            bonds=(
+                molecule.Bond(
+                    atom1_id=bond.get_atom1().get_id(),
+                    atom2_id=bond.get_atom2().get_id(),
+                    order=bond.get_order(),
+                ) for bond in cage.get_bonds()
+            ),
+        )
+
     Nonlinear building blocks with five functional groups are
     required for this topology.
 

--- a/src/stk/molecular/topology_graphs/cage/two_plus_five/twelve_plus_thirty.py
+++ b/src/stk/molecular/topology_graphs/cage/two_plus_five/twelve_plus_thirty.py
@@ -15,6 +15,8 @@ class TwelvePlusThirty(Cage):
     """
     Represents a icosahedron cage topology graph.
 
+    Unoptimized construction
+
     .. moldoc::
 
         import moldoc.molecule as molecule
@@ -30,6 +32,47 @@ class TwelvePlusThirty(Cage):
         )
         cage = stk.ConstructedMolecule(
             topology_graph=stk.cage.TwelvePlusThirty((bb1, bb2)),
+        )
+
+        moldoc_display_molecule = molecule.Molecule(
+            atoms=(
+                molecule.Atom(
+                    atomic_number=atom.get_atomic_number(),
+                    position=position,
+                ) for atom, position in zip(
+                    cage.get_atoms(),
+                    cage.get_position_matrix(),
+                )
+            ),
+            bonds=(
+                molecule.Bond(
+                    atom1_id=bond.get_atom1().get_id(),
+                    atom2_id=bond.get_atom2().get_id(),
+                    order=bond.get_order(),
+                ) for bond in cage.get_bonds()
+            ),
+        )
+
+    :class:`.Collapser` optimized construction
+
+    .. moldoc::
+
+        import moldoc.molecule as molecule
+        import stk
+
+        bb1 = stk.BuildingBlock(
+            smiles='BrCCBr',
+            functional_groups=[stk.BromoFactory()],
+        )
+        bb2 = stk.BuildingBlock(
+            smiles='BrC1C(Br)C(Br)C(Br)C1Br',
+            functional_groups=[stk.BromoFactory()],
+        )
+        cage = stk.ConstructedMolecule(
+            topology_graph=stk.cage.TwelvePlusThirty(
+                building_blocks=(bb1, bb2),
+                optimizer=stk.Collapser(),
+            ),
         )
 
         moldoc_display_molecule = molecule.Molecule(

--- a/src/stk/molecular/topology_graphs/cage/two_plus_four/eight_plus_sixteen.py
+++ b/src/stk/molecular/topology_graphs/cage/two_plus_four/eight_plus_sixteen.py
@@ -15,6 +15,42 @@ class EightPlusSixteen(Cage):
     """
     Represents a cage topology graph.
 
+    .. moldoc::
+
+        import moldoc.molecule as molecule
+        import stk
+
+        bb1 = stk.BuildingBlock(
+            smiles='BrCCBr',
+            functional_groups=[stk.BromoFactory()],
+        )
+        bb2 = stk.BuildingBlock(
+            smiles='Brc1c(Br)cc(Br)c(Br)c1',
+            functional_groups=[stk.BromoFactory()],
+        )
+        cage = stk.ConstructedMolecule(
+            topology_graph=stk.cage.EightPlusSixteen((bb1, bb2)),
+        )
+
+        moldoc_display_molecule = molecule.Molecule(
+            atoms=(
+                molecule.Atom(
+                    atomic_number=atom.get_atomic_number(),
+                    position=position,
+                ) for atom, position in zip(
+                    cage.get_atoms(),
+                    cage.get_position_matrix(),
+                )
+            ),
+            bonds=(
+                molecule.Bond(
+                    atom1_id=bond.get_atom1().get_id(),
+                    atom2_id=bond.get_atom2().get_id(),
+                    order=bond.get_order(),
+                ) for bond in cage.get_bonds()
+            ),
+        )
+
     Nonlinear building blocks with four functional groups are
     required for this topology.
 

--- a/src/stk/molecular/topology_graphs/cage/two_plus_four/eight_plus_sixteen.py
+++ b/src/stk/molecular/topology_graphs/cage/two_plus_four/eight_plus_sixteen.py
@@ -15,6 +15,8 @@ class EightPlusSixteen(Cage):
     """
     Represents a cage topology graph.
 
+    Unoptimized construction
+
     .. moldoc::
 
         import moldoc.molecule as molecule
@@ -30,6 +32,47 @@ class EightPlusSixteen(Cage):
         )
         cage = stk.ConstructedMolecule(
             topology_graph=stk.cage.EightPlusSixteen((bb1, bb2)),
+        )
+
+        moldoc_display_molecule = molecule.Molecule(
+            atoms=(
+                molecule.Atom(
+                    atomic_number=atom.get_atomic_number(),
+                    position=position,
+                ) for atom, position in zip(
+                    cage.get_atoms(),
+                    cage.get_position_matrix(),
+                )
+            ),
+            bonds=(
+                molecule.Bond(
+                    atom1_id=bond.get_atom1().get_id(),
+                    atom2_id=bond.get_atom2().get_id(),
+                    order=bond.get_order(),
+                ) for bond in cage.get_bonds()
+            ),
+        )
+
+    :class:`.Collapser` optimized construction
+
+    .. moldoc::
+
+        import moldoc.molecule as molecule
+        import stk
+
+        bb1 = stk.BuildingBlock(
+            smiles='BrCCBr',
+            functional_groups=[stk.BromoFactory()],
+        )
+        bb2 = stk.BuildingBlock(
+            smiles='Brc1c(Br)cc(Br)c(Br)c1',
+            functional_groups=[stk.BromoFactory()],
+        )
+        cage = stk.ConstructedMolecule(
+            topology_graph=stk.cage.EightPlusSixteen(
+                building_blocks=(bb1, bb2),
+                optimizer=stk.Collapser(),
+            ),
         )
 
         moldoc_display_molecule = molecule.Molecule(

--- a/src/stk/molecular/topology_graphs/cage/two_plus_four/five_plus_ten.py
+++ b/src/stk/molecular/topology_graphs/cage/two_plus_four/five_plus_ten.py
@@ -15,6 +15,8 @@ class FivePlusTen(Cage):
     """
     Represents a cage topology graph.
 
+    Unoptimized construction
+
     .. moldoc::
 
         import moldoc.molecule as molecule
@@ -30,6 +32,47 @@ class FivePlusTen(Cage):
         )
         cage = stk.ConstructedMolecule(
             topology_graph=stk.cage.FivePlusTen((bb1, bb2)),
+        )
+
+        moldoc_display_molecule = molecule.Molecule(
+            atoms=(
+                molecule.Atom(
+                    atomic_number=atom.get_atomic_number(),
+                    position=position,
+                ) for atom, position in zip(
+                    cage.get_atoms(),
+                    cage.get_position_matrix(),
+                )
+            ),
+            bonds=(
+                molecule.Bond(
+                    atom1_id=bond.get_atom1().get_id(),
+                    atom2_id=bond.get_atom2().get_id(),
+                    order=bond.get_order(),
+                ) for bond in cage.get_bonds()
+            ),
+        )
+
+    :class:`.Collapser` optimized construction
+
+    .. moldoc::
+
+        import moldoc.molecule as molecule
+        import stk
+
+        bb1 = stk.BuildingBlock(
+            smiles='BrCCBr',
+            functional_groups=[stk.BromoFactory()],
+        )
+        bb2 = stk.BuildingBlock(
+            smiles='Brc1c(Br)cc(Br)c(Br)c1',
+            functional_groups=[stk.BromoFactory()],
+        )
+        cage = stk.ConstructedMolecule(
+            topology_graph=stk.cage.FivePlusTen(
+                building_blocks=(bb1, bb2),
+                optimizer=stk.Collapser(),
+            ),
         )
 
         moldoc_display_molecule = molecule.Molecule(

--- a/src/stk/molecular/topology_graphs/cage/two_plus_four/five_plus_ten.py
+++ b/src/stk/molecular/topology_graphs/cage/two_plus_four/five_plus_ten.py
@@ -15,6 +15,42 @@ class FivePlusTen(Cage):
     """
     Represents a cage topology graph.
 
+    .. moldoc::
+
+        import moldoc.molecule as molecule
+        import stk
+
+        bb1 = stk.BuildingBlock(
+            smiles='BrCCBr',
+            functional_groups=[stk.BromoFactory()],
+        )
+        bb2 = stk.BuildingBlock(
+            smiles='Brc1c(Br)cc(Br)c(Br)c1',
+            functional_groups=[stk.BromoFactory()],
+        )
+        cage = stk.ConstructedMolecule(
+            topology_graph=stk.cage.FivePlusTen((bb1, bb2)),
+        )
+
+        moldoc_display_molecule = molecule.Molecule(
+            atoms=(
+                molecule.Atom(
+                    atomic_number=atom.get_atomic_number(),
+                    position=position,
+                ) for atom, position in zip(
+                    cage.get_atoms(),
+                    cage.get_position_matrix(),
+                )
+            ),
+            bonds=(
+                molecule.Bond(
+                    atom1_id=bond.get_atom1().get_id(),
+                    atom2_id=bond.get_atom2().get_id(),
+                    order=bond.get_order(),
+                ) for bond in cage.get_bonds()
+            ),
+        )
+
     Nonlinear building blocks with four functional groups are
     required for this topology.
 

--- a/src/stk/molecular/topology_graphs/cage/two_plus_four/four_plus_eight.py
+++ b/src/stk/molecular/topology_graphs/cage/two_plus_four/four_plus_eight.py
@@ -13,6 +13,8 @@ class FourPlusEight(Cage):
     """
     Represents a cage topology graph.
 
+    Unoptimized construction
+
     .. moldoc::
 
         import moldoc.molecule as molecule
@@ -28,6 +30,47 @@ class FourPlusEight(Cage):
         )
         cage = stk.ConstructedMolecule(
             topology_graph=stk.cage.FourPlusEight((bb1, bb2)),
+        )
+
+        moldoc_display_molecule = molecule.Molecule(
+            atoms=(
+                molecule.Atom(
+                    atomic_number=atom.get_atomic_number(),
+                    position=position,
+                ) for atom, position in zip(
+                    cage.get_atoms(),
+                    cage.get_position_matrix(),
+                )
+            ),
+            bonds=(
+                molecule.Bond(
+                    atom1_id=bond.get_atom1().get_id(),
+                    atom2_id=bond.get_atom2().get_id(),
+                    order=bond.get_order(),
+                ) for bond in cage.get_bonds()
+            ),
+        )
+
+    :class:`.Collapser` optimized construction
+
+    .. moldoc::
+
+        import moldoc.molecule as molecule
+        import stk
+
+        bb1 = stk.BuildingBlock(
+            smiles='BrCCBr',
+            functional_groups=[stk.BromoFactory()],
+        )
+        bb2 = stk.BuildingBlock(
+            smiles='Brc1c(Br)cc(Br)c(Br)c1',
+            functional_groups=[stk.BromoFactory()],
+        )
+        cage = stk.ConstructedMolecule(
+            topology_graph=stk.cage.FourPlusEight(
+                building_blocks=(bb1, bb2),
+                optimizer=stk.Collapser(),
+            ),
         )
 
         moldoc_display_molecule = molecule.Molecule(

--- a/src/stk/molecular/topology_graphs/cage/two_plus_four/four_plus_eight.py
+++ b/src/stk/molecular/topology_graphs/cage/two_plus_four/four_plus_eight.py
@@ -13,6 +13,42 @@ class FourPlusEight(Cage):
     """
     Represents a cage topology graph.
 
+    .. moldoc::
+
+        import moldoc.molecule as molecule
+        import stk
+
+        bb1 = stk.BuildingBlock(
+            smiles='BrCCBr',
+            functional_groups=[stk.BromoFactory()],
+        )
+        bb2 = stk.BuildingBlock(
+            smiles='Brc1c(Br)cc(Br)c(Br)c1',
+            functional_groups=[stk.BromoFactory()],
+        )
+        cage = stk.ConstructedMolecule(
+            topology_graph=stk.cage.FourPlusEight((bb1, bb2)),
+        )
+
+        moldoc_display_molecule = molecule.Molecule(
+            atoms=(
+                molecule.Atom(
+                    atomic_number=atom.get_atomic_number(),
+                    position=position,
+                ) for atom, position in zip(
+                    cage.get_atoms(),
+                    cage.get_position_matrix(),
+                )
+            ),
+            bonds=(
+                molecule.Bond(
+                    atom1_id=bond.get_atom1().get_id(),
+                    atom2_id=bond.get_atom2().get_id(),
+                    order=bond.get_order(),
+                ) for bond in cage.get_bonds()
+            ),
+        )
+
     Nonlinear building blocks with four functional groups are
     required for this topology.
 

--- a/src/stk/molecular/topology_graphs/cage/two_plus_four/six_plus_twelve.py
+++ b/src/stk/molecular/topology_graphs/cage/two_plus_four/six_plus_twelve.py
@@ -13,6 +13,42 @@ class SixPlusTwelve(Cage):
     """
     Represents a cage topology graph.
 
+    .. moldoc::
+
+        import moldoc.molecule as molecule
+        import stk
+
+        bb1 = stk.BuildingBlock(
+            smiles='BrCCBr',
+            functional_groups=[stk.BromoFactory()],
+        )
+        bb2 = stk.BuildingBlock(
+            smiles='Brc1c(Br)cc(Br)c(Br)c1',
+            functional_groups=[stk.BromoFactory()],
+        )
+        cage = stk.ConstructedMolecule(
+            topology_graph=stk.cage.SixPlusTwelve((bb1, bb2)),
+        )
+
+        moldoc_display_molecule = molecule.Molecule(
+            atoms=(
+                molecule.Atom(
+                    atomic_number=atom.get_atomic_number(),
+                    position=position,
+                ) for atom, position in zip(
+                    cage.get_atoms(),
+                    cage.get_position_matrix(),
+                )
+            ),
+            bonds=(
+                molecule.Bond(
+                    atom1_id=bond.get_atom1().get_id(),
+                    atom2_id=bond.get_atom2().get_id(),
+                    order=bond.get_order(),
+                ) for bond in cage.get_bonds()
+            ),
+        )
+
     Nonlinear building blocks with four functional groups are
     required for this topology.
 

--- a/src/stk/molecular/topology_graphs/cage/two_plus_four/six_plus_twelve.py
+++ b/src/stk/molecular/topology_graphs/cage/two_plus_four/six_plus_twelve.py
@@ -13,6 +13,8 @@ class SixPlusTwelve(Cage):
     """
     Represents a cage topology graph.
 
+    Unoptimized construction
+
     .. moldoc::
 
         import moldoc.molecule as molecule
@@ -28,6 +30,47 @@ class SixPlusTwelve(Cage):
         )
         cage = stk.ConstructedMolecule(
             topology_graph=stk.cage.SixPlusTwelve((bb1, bb2)),
+        )
+
+        moldoc_display_molecule = molecule.Molecule(
+            atoms=(
+                molecule.Atom(
+                    atomic_number=atom.get_atomic_number(),
+                    position=position,
+                ) for atom, position in zip(
+                    cage.get_atoms(),
+                    cage.get_position_matrix(),
+                )
+            ),
+            bonds=(
+                molecule.Bond(
+                    atom1_id=bond.get_atom1().get_id(),
+                    atom2_id=bond.get_atom2().get_id(),
+                    order=bond.get_order(),
+                ) for bond in cage.get_bonds()
+            ),
+        )
+
+    :class:`.Collapser` optimized construction
+
+    .. moldoc::
+
+        import moldoc.molecule as molecule
+        import stk
+
+        bb1 = stk.BuildingBlock(
+            smiles='BrCCBr',
+            functional_groups=[stk.BromoFactory()],
+        )
+        bb2 = stk.BuildingBlock(
+            smiles='Brc1c(Br)cc(Br)c(Br)c1',
+            functional_groups=[stk.BromoFactory()],
+        )
+        cage = stk.ConstructedMolecule(
+            topology_graph=stk.cage.SixPlusTwelve(
+                building_blocks=(bb1, bb2),
+                optimizer=stk.Collapser(),
+            ),
         )
 
         moldoc_display_molecule = molecule.Molecule(

--- a/src/stk/molecular/topology_graphs/cage/two_plus_four/ten_plus_twenty.py
+++ b/src/stk/molecular/topology_graphs/cage/two_plus_four/ten_plus_twenty.py
@@ -13,6 +13,42 @@ class TenPlusTwenty(Cage):
     """
     Represents a cage topology graph.
 
+    .. moldoc::
+
+        import moldoc.molecule as molecule
+        import stk
+
+        bb1 = stk.BuildingBlock(
+            smiles='BrCCBr',
+            functional_groups=[stk.BromoFactory()],
+        )
+        bb2 = stk.BuildingBlock(
+            smiles='Brc1c(Br)cc(Br)c(Br)c1',
+            functional_groups=[stk.BromoFactory()],
+        )
+        cage = stk.ConstructedMolecule(
+            topology_graph=stk.cage.TenPlusTwenty((bb1, bb2)),
+        )
+
+        moldoc_display_molecule = molecule.Molecule(
+            atoms=(
+                molecule.Atom(
+                    atomic_number=atom.get_atomic_number(),
+                    position=position,
+                ) for atom, position in zip(
+                    cage.get_atoms(),
+                    cage.get_position_matrix(),
+                )
+            ),
+            bonds=(
+                molecule.Bond(
+                    atom1_id=bond.get_atom1().get_id(),
+                    atom2_id=bond.get_atom2().get_id(),
+                    order=bond.get_order(),
+                ) for bond in cage.get_bonds()
+            ),
+        )
+
     Nonlinear building blocks with four functional groups are
     required for this topology.
 

--- a/src/stk/molecular/topology_graphs/cage/two_plus_four/ten_plus_twenty.py
+++ b/src/stk/molecular/topology_graphs/cage/two_plus_four/ten_plus_twenty.py
@@ -13,6 +13,8 @@ class TenPlusTwenty(Cage):
     """
     Represents a cage topology graph.
 
+    Unoptimized construction
+
     .. moldoc::
 
         import moldoc.molecule as molecule
@@ -28,6 +30,47 @@ class TenPlusTwenty(Cage):
         )
         cage = stk.ConstructedMolecule(
             topology_graph=stk.cage.TenPlusTwenty((bb1, bb2)),
+        )
+
+        moldoc_display_molecule = molecule.Molecule(
+            atoms=(
+                molecule.Atom(
+                    atomic_number=atom.get_atomic_number(),
+                    position=position,
+                ) for atom, position in zip(
+                    cage.get_atoms(),
+                    cage.get_position_matrix(),
+                )
+            ),
+            bonds=(
+                molecule.Bond(
+                    atom1_id=bond.get_atom1().get_id(),
+                    atom2_id=bond.get_atom2().get_id(),
+                    order=bond.get_order(),
+                ) for bond in cage.get_bonds()
+            ),
+        )
+
+    :class:`.Collapser` optimized construction
+
+    .. moldoc::
+
+        import moldoc.molecule as molecule
+        import stk
+
+        bb1 = stk.BuildingBlock(
+            smiles='BrCCBr',
+            functional_groups=[stk.BromoFactory()],
+        )
+        bb2 = stk.BuildingBlock(
+            smiles='Brc1c(Br)cc(Br)c(Br)c1',
+            functional_groups=[stk.BromoFactory()],
+        )
+        cage = stk.ConstructedMolecule(
+            topology_graph=stk.cage.TenPlusTwenty(
+                building_blocks=(bb1, bb2),
+                optimizer=stk.Collapser(),
+            ),
         )
 
         moldoc_display_molecule = molecule.Molecule(

--- a/src/stk/molecular/topology_graphs/cage/two_plus_four/three_plus_six.py
+++ b/src/stk/molecular/topology_graphs/cage/two_plus_four/three_plus_six.py
@@ -15,6 +15,8 @@ class ThreePlusSix(Cage):
     """
     Represents a cage topology graph.
 
+    Unoptimized construction
+
     .. moldoc::
 
         import moldoc.molecule as molecule
@@ -30,6 +32,47 @@ class ThreePlusSix(Cage):
         )
         cage = stk.ConstructedMolecule(
             topology_graph=stk.cage.ThreePlusSix((bb1, bb2)),
+        )
+
+        moldoc_display_molecule = molecule.Molecule(
+            atoms=(
+                molecule.Atom(
+                    atomic_number=atom.get_atomic_number(),
+                    position=position,
+                ) for atom, position in zip(
+                    cage.get_atoms(),
+                    cage.get_position_matrix(),
+                )
+            ),
+            bonds=(
+                molecule.Bond(
+                    atom1_id=bond.get_atom1().get_id(),
+                    atom2_id=bond.get_atom2().get_id(),
+                    order=bond.get_order(),
+                ) for bond in cage.get_bonds()
+            ),
+        )
+
+    :class:`.Collapser` optimized construction
+
+    .. moldoc::
+
+        import moldoc.molecule as molecule
+        import stk
+
+        bb1 = stk.BuildingBlock(
+            smiles='BrCCBr',
+            functional_groups=[stk.BromoFactory()],
+        )
+        bb2 = stk.BuildingBlock(
+            smiles='Brc1c(Br)cc(Br)c(Br)c1',
+            functional_groups=[stk.BromoFactory()],
+        )
+        cage = stk.ConstructedMolecule(
+            topology_graph=stk.cage.ThreePlusSix(
+                building_blocks=(bb1, bb2),
+                optimizer=stk.Collapser(),
+            ),
         )
 
         moldoc_display_molecule = molecule.Molecule(

--- a/src/stk/molecular/topology_graphs/cage/two_plus_four/three_plus_six.py
+++ b/src/stk/molecular/topology_graphs/cage/two_plus_four/three_plus_six.py
@@ -15,6 +15,42 @@ class ThreePlusSix(Cage):
     """
     Represents a cage topology graph.
 
+    .. moldoc::
+
+        import moldoc.molecule as molecule
+        import stk
+
+        bb1 = stk.BuildingBlock(
+            smiles='BrCCBr',
+            functional_groups=[stk.BromoFactory()],
+        )
+        bb2 = stk.BuildingBlock(
+            smiles='Brc1c(Br)cc(Br)c(Br)c1',
+            functional_groups=[stk.BromoFactory()],
+        )
+        cage = stk.ConstructedMolecule(
+            topology_graph=stk.cage.ThreePlusSix((bb1, bb2)),
+        )
+
+        moldoc_display_molecule = molecule.Molecule(
+            atoms=(
+                molecule.Atom(
+                    atomic_number=atom.get_atomic_number(),
+                    position=position,
+                ) for atom, position in zip(
+                    cage.get_atoms(),
+                    cage.get_position_matrix(),
+                )
+            ),
+            bonds=(
+                molecule.Bond(
+                    atom1_id=bond.get_atom1().get_id(),
+                    atom2_id=bond.get_atom2().get_id(),
+                    order=bond.get_order(),
+                ) for bond in cage.get_bonds()
+            ),
+        )
+
     Nonlinear building blocks with four functional groups are
     required for this topology.
 

--- a/src/stk/molecular/topology_graphs/cage/two_plus_four/two_plus_four.py
+++ b/src/stk/molecular/topology_graphs/cage/two_plus_four/two_plus_four.py
@@ -13,6 +13,42 @@ class TwoPlusFour(Cage):
     """
     Represents a capsule cage topology graph.
 
+    .. moldoc::
+
+        import moldoc.molecule as molecule
+        import stk
+
+        bb1 = stk.BuildingBlock(
+            smiles='BrCCBr',
+            functional_groups=[stk.BromoFactory()],
+        )
+        bb2 = stk.BuildingBlock(
+            smiles='Brc1c(Br)cc(Br)c(Br)c1',
+            functional_groups=[stk.BromoFactory()],
+        )
+        cage = stk.ConstructedMolecule(
+            topology_graph=stk.cage.TwoPlusFour((bb1, bb2)),
+        )
+
+        moldoc_display_molecule = molecule.Molecule(
+            atoms=(
+                molecule.Atom(
+                    atomic_number=atom.get_atomic_number(),
+                    position=position,
+                ) for atom, position in zip(
+                    cage.get_atoms(),
+                    cage.get_position_matrix(),
+                )
+            ),
+            bonds=(
+                molecule.Bond(
+                    atom1_id=bond.get_atom1().get_id(),
+                    atom2_id=bond.get_atom2().get_id(),
+                    order=bond.get_order(),
+                ) for bond in cage.get_bonds()
+            ),
+        )
+
     Nonlinear building blocks with four functional groups are
     required for this topology.
 

--- a/src/stk/molecular/topology_graphs/cage/two_plus_four/two_plus_four.py
+++ b/src/stk/molecular/topology_graphs/cage/two_plus_four/two_plus_four.py
@@ -13,6 +13,8 @@ class TwoPlusFour(Cage):
     """
     Represents a capsule cage topology graph.
 
+    Unoptimized construction
+
     .. moldoc::
 
         import moldoc.molecule as molecule
@@ -28,6 +30,47 @@ class TwoPlusFour(Cage):
         )
         cage = stk.ConstructedMolecule(
             topology_graph=stk.cage.TwoPlusFour((bb1, bb2)),
+        )
+
+        moldoc_display_molecule = molecule.Molecule(
+            atoms=(
+                molecule.Atom(
+                    atomic_number=atom.get_atomic_number(),
+                    position=position,
+                ) for atom, position in zip(
+                    cage.get_atoms(),
+                    cage.get_position_matrix(),
+                )
+            ),
+            bonds=(
+                molecule.Bond(
+                    atom1_id=bond.get_atom1().get_id(),
+                    atom2_id=bond.get_atom2().get_id(),
+                    order=bond.get_order(),
+                ) for bond in cage.get_bonds()
+            ),
+        )
+
+    :class:`.Collapser` optimized construction
+
+    .. moldoc::
+
+        import moldoc.molecule as molecule
+        import stk
+
+        bb1 = stk.BuildingBlock(
+            smiles='BrCCBr',
+            functional_groups=[stk.BromoFactory()],
+        )
+        bb2 = stk.BuildingBlock(
+            smiles='Brc1c(Br)cc(Br)c(Br)c1',
+            functional_groups=[stk.BromoFactory()],
+        )
+        cage = stk.ConstructedMolecule(
+            topology_graph=stk.cage.TwoPlusFour(
+                building_blocks=(bb1, bb2),
+                optimizer=stk.Collapser(),
+            ),
         )
 
         moldoc_display_molecule = molecule.Molecule(

--- a/src/stk/molecular/topology_graphs/cage/two_plus_three/eight_plus_twelve.py
+++ b/src/stk/molecular/topology_graphs/cage/two_plus_three/eight_plus_twelve.py
@@ -13,21 +13,64 @@ class EightPlusTwelve(Cage):
     """
     Represents a cage topology graph.
 
+    Unoptimized construction
+
     .. moldoc::
 
         import moldoc.molecule as molecule
         import stk
 
         bb1 = stk.BuildingBlock(
-            smiles='BrCCBr',
-            functional_groups=[stk.BromoFactory()],
+            smiles='NC1CCCCC1N',
+            functional_groups=[stk.PrimaryAminoFactory()],
         )
         bb2 = stk.BuildingBlock(
-            smiles='Brc1cc(Br)cc(Br)c1',
-            functional_groups=[stk.BromoFactory()],
+            smiles='O=Cc1cc(C=O)cc(C=O)c1',
+            functional_groups=[stk.AldehydeFactory()],
         )
         cage = stk.ConstructedMolecule(
             topology_graph=stk.cage.EightPlusTwelve((bb1, bb2)),
+        )
+
+        moldoc_display_molecule = molecule.Molecule(
+            atoms=(
+                molecule.Atom(
+                    atomic_number=atom.get_atomic_number(),
+                    position=position,
+                ) for atom, position in zip(
+                    cage.get_atoms(),
+                    cage.get_position_matrix(),
+                )
+            ),
+            bonds=(
+                molecule.Bond(
+                    atom1_id=bond.get_atom1().get_id(),
+                    atom2_id=bond.get_atom2().get_id(),
+                    order=bond.get_order(),
+                ) for bond in cage.get_bonds()
+            ),
+        )
+
+    :class:`.MCHammer` optimized construction
+
+    .. moldoc::
+
+        import moldoc.molecule as molecule
+        import stk
+
+        bb1 = stk.BuildingBlock(
+            smiles='NC1CCCCC1N',
+            functional_groups=[stk.PrimaryAminoFactory()],
+        )
+        bb2 = stk.BuildingBlock(
+            smiles='O=Cc1cc(C=O)cc(C=O)c1',
+            functional_groups=[stk.AldehydeFactory()],
+        )
+        cage = stk.ConstructedMolecule(
+            topology_graph=stk.cage.EightPlusTwelve(
+                building_blocks=(bb1, bb2),
+                optimizer=stk.MCHammer(num_steps=1000),
+            ),
         )
 
         moldoc_display_molecule = molecule.Molecule(

--- a/src/stk/molecular/topology_graphs/cage/two_plus_three/eight_plus_twelve.py
+++ b/src/stk/molecular/topology_graphs/cage/two_plus_three/eight_plus_twelve.py
@@ -13,6 +13,42 @@ class EightPlusTwelve(Cage):
     """
     Represents a cage topology graph.
 
+    .. moldoc::
+
+        import moldoc.molecule as molecule
+        import stk
+
+        bb1 = stk.BuildingBlock(
+            smiles='BrCCBr',
+            functional_groups=[stk.BromoFactory()],
+        )
+        bb2 = stk.BuildingBlock(
+            smiles='Brc1cc(Br)cc(Br)c1',
+            functional_groups=[stk.BromoFactory()],
+        )
+        cage = stk.ConstructedMolecule(
+            topology_graph=stk.cage.EightPlusTwelve((bb1, bb2)),
+        )
+
+        moldoc_display_molecule = molecule.Molecule(
+            atoms=(
+                molecule.Atom(
+                    atomic_number=atom.get_atomic_number(),
+                    position=position,
+                ) for atom, position in zip(
+                    cage.get_atoms(),
+                    cage.get_position_matrix(),
+                )
+            ),
+            bonds=(
+                molecule.Bond(
+                    atom1_id=bond.get_atom1().get_id(),
+                    atom2_id=bond.get_atom2().get_id(),
+                    order=bond.get_order(),
+                ) for bond in cage.get_bonds()
+            ),
+        )
+
     Nonlinear building blocks with three functional groups are
     required for this topology.
 

--- a/src/stk/molecular/topology_graphs/cage/two_plus_three/four_plus_six.py
+++ b/src/stk/molecular/topology_graphs/cage/two_plus_three/four_plus_six.py
@@ -15,6 +15,42 @@ class FourPlusSix(Cage):
     """
     Represents a cage topology graph.
 
+    .. moldoc::
+
+        import moldoc.molecule as molecule
+        import stk
+
+        bb1 = stk.BuildingBlock(
+            smiles='BrCCBr',
+            functional_groups=[stk.BromoFactory()],
+        )
+        bb2 = stk.BuildingBlock(
+            smiles='Brc1cc(Br)cc(Br)c1',
+            functional_groups=[stk.BromoFactory()],
+        )
+        cage = stk.ConstructedMolecule(
+            topology_graph=stk.cage.FourPlusSix((bb1, bb2)),
+        )
+
+        moldoc_display_molecule = molecule.Molecule(
+            atoms=(
+                molecule.Atom(
+                    atomic_number=atom.get_atomic_number(),
+                    position=position,
+                ) for atom, position in zip(
+                    cage.get_atoms(),
+                    cage.get_position_matrix(),
+                )
+            ),
+            bonds=(
+                molecule.Bond(
+                    atom1_id=bond.get_atom1().get_id(),
+                    atom2_id=bond.get_atom2().get_id(),
+                    order=bond.get_order(),
+                ) for bond in cage.get_bonds()
+            ),
+        )
+
     Nonlinear building blocks with three functional groups are
     required for this topology.
 

--- a/src/stk/molecular/topology_graphs/cage/two_plus_three/four_plus_six.py
+++ b/src/stk/molecular/topology_graphs/cage/two_plus_three/four_plus_six.py
@@ -15,21 +15,64 @@ class FourPlusSix(Cage):
     """
     Represents a cage topology graph.
 
+    Unoptimized construction
+
     .. moldoc::
 
         import moldoc.molecule as molecule
         import stk
 
         bb1 = stk.BuildingBlock(
-            smiles='BrCCBr',
-            functional_groups=[stk.BromoFactory()],
+            smiles='NC1CCCCC1N',
+            functional_groups=[stk.PrimaryAminoFactory()],
         )
         bb2 = stk.BuildingBlock(
-            smiles='Brc1cc(Br)cc(Br)c1',
-            functional_groups=[stk.BromoFactory()],
+            smiles='O=Cc1cc(C=O)cc(C=O)c1',
+            functional_groups=[stk.AldehydeFactory()],
         )
         cage = stk.ConstructedMolecule(
             topology_graph=stk.cage.FourPlusSix((bb1, bb2)),
+        )
+
+        moldoc_display_molecule = molecule.Molecule(
+            atoms=(
+                molecule.Atom(
+                    atomic_number=atom.get_atomic_number(),
+                    position=position,
+                ) for atom, position in zip(
+                    cage.get_atoms(),
+                    cage.get_position_matrix(),
+                )
+            ),
+            bonds=(
+                molecule.Bond(
+                    atom1_id=bond.get_atom1().get_id(),
+                    atom2_id=bond.get_atom2().get_id(),
+                    order=bond.get_order(),
+                ) for bond in cage.get_bonds()
+            ),
+        )
+
+    :class:`.MCHammer` optimized construction
+
+    .. moldoc::
+
+        import moldoc.molecule as molecule
+        import stk
+
+        bb1 = stk.BuildingBlock(
+            smiles='NC1CCCCC1N',
+            functional_groups=[stk.PrimaryAminoFactory()],
+        )
+        bb2 = stk.BuildingBlock(
+            smiles='O=Cc1cc(C=O)cc(C=O)c1',
+            functional_groups=[stk.AldehydeFactory()],
+        )
+        cage = stk.ConstructedMolecule(
+            topology_graph=stk.cage.FourPlusSix(
+                building_blocks=(bb1, bb2),
+                optimizer=stk.MCHammer(),
+            ),
         )
 
         moldoc_display_molecule = molecule.Molecule(

--- a/src/stk/molecular/topology_graphs/cage/two_plus_three/four_plus_six_2.py
+++ b/src/stk/molecular/topology_graphs/cage/two_plus_three/four_plus_six_2.py
@@ -13,21 +13,64 @@ class FourPlusSix2(Cage):
     """
     Represents a cage topology graph.
 
+    Unoptimized construction
+
     .. moldoc::
 
         import moldoc.molecule as molecule
         import stk
 
         bb1 = stk.BuildingBlock(
-            smiles='BrCCBr',
-            functional_groups=[stk.BromoFactory()],
+            smiles='NC1CCCCC1N',
+            functional_groups=[stk.PrimaryAminoFactory()],
         )
         bb2 = stk.BuildingBlock(
-            smiles='Brc1cc(Br)cc(Br)c1',
-            functional_groups=[stk.BromoFactory()],
+            smiles='O=Cc1cc(C=O)cc(C=O)c1',
+            functional_groups=[stk.AldehydeFactory()],
         )
         cage = stk.ConstructedMolecule(
             topology_graph=stk.cage.FourPlusSix2((bb1, bb2)),
+        )
+
+        moldoc_display_molecule = molecule.Molecule(
+            atoms=(
+                molecule.Atom(
+                    atomic_number=atom.get_atomic_number(),
+                    position=position,
+                ) for atom, position in zip(
+                    cage.get_atoms(),
+                    cage.get_position_matrix(),
+                )
+            ),
+            bonds=(
+                molecule.Bond(
+                    atom1_id=bond.get_atom1().get_id(),
+                    atom2_id=bond.get_atom2().get_id(),
+                    order=bond.get_order(),
+                ) for bond in cage.get_bonds()
+            ),
+        )
+
+    :class:`.MCHammer` optimized construction
+
+    .. moldoc::
+
+        import moldoc.molecule as molecule
+        import stk
+
+        bb1 = stk.BuildingBlock(
+            smiles='NC1CCCCC1N',
+            functional_groups=[stk.PrimaryAminoFactory()],
+        )
+        bb2 = stk.BuildingBlock(
+            smiles='O=Cc1cc(C=O)cc(C=O)c1',
+            functional_groups=[stk.AldehydeFactory()],
+        )
+        cage = stk.ConstructedMolecule(
+            topology_graph=stk.cage.FourPlusSix2(
+                building_blocks=(bb1, bb2),
+                optimizer=stk.MCHammer(),
+            ),
         )
 
         moldoc_display_molecule = molecule.Molecule(

--- a/src/stk/molecular/topology_graphs/cage/two_plus_three/four_plus_six_2.py
+++ b/src/stk/molecular/topology_graphs/cage/two_plus_three/four_plus_six_2.py
@@ -13,6 +13,42 @@ class FourPlusSix2(Cage):
     """
     Represents a cage topology graph.
 
+    .. moldoc::
+
+        import moldoc.molecule as molecule
+        import stk
+
+        bb1 = stk.BuildingBlock(
+            smiles='BrCCBr',
+            functional_groups=[stk.BromoFactory()],
+        )
+        bb2 = stk.BuildingBlock(
+            smiles='Brc1cc(Br)cc(Br)c1',
+            functional_groups=[stk.BromoFactory()],
+        )
+        cage = stk.ConstructedMolecule(
+            topology_graph=stk.cage.FourPlusSix2((bb1, bb2)),
+        )
+
+        moldoc_display_molecule = molecule.Molecule(
+            atoms=(
+                molecule.Atom(
+                    atomic_number=atom.get_atomic_number(),
+                    position=position,
+                ) for atom, position in zip(
+                    cage.get_atoms(),
+                    cage.get_position_matrix(),
+                )
+            ),
+            bonds=(
+                molecule.Bond(
+                    atom1_id=bond.get_atom1().get_id(),
+                    atom2_id=bond.get_atom2().get_id(),
+                    order=bond.get_order(),
+                ) for bond in cage.get_bonds()
+            ),
+        )
+
     Nonlinear building blocks with three functional groups are
     required for this topology.
 

--- a/src/stk/molecular/topology_graphs/cage/two_plus_three/six_plus_nine.py
+++ b/src/stk/molecular/topology_graphs/cage/two_plus_three/six_plus_nine.py
@@ -15,21 +15,64 @@ class SixPlusNine(Cage):
     """
     Represents a cage topology graph.
 
+    Unoptimized construction
+
     .. moldoc::
 
         import moldoc.molecule as molecule
         import stk
 
         bb1 = stk.BuildingBlock(
-            smiles='BrCCBr',
-            functional_groups=[stk.BromoFactory()],
+            smiles='NC1CCCCC1N',
+            functional_groups=[stk.PrimaryAminoFactory()],
         )
         bb2 = stk.BuildingBlock(
-            smiles='Brc1cc(Br)cc(Br)c1',
-            functional_groups=[stk.BromoFactory()],
+            smiles='O=Cc1cc(C=O)cc(C=O)c1',
+            functional_groups=[stk.AldehydeFactory()],
         )
         cage = stk.ConstructedMolecule(
             topology_graph=stk.cage.SixPlusNine((bb1, bb2)),
+        )
+
+        moldoc_display_molecule = molecule.Molecule(
+            atoms=(
+                molecule.Atom(
+                    atomic_number=atom.get_atomic_number(),
+                    position=position,
+                ) for atom, position in zip(
+                    cage.get_atoms(),
+                    cage.get_position_matrix(),
+                )
+            ),
+            bonds=(
+                molecule.Bond(
+                    atom1_id=bond.get_atom1().get_id(),
+                    atom2_id=bond.get_atom2().get_id(),
+                    order=bond.get_order(),
+                ) for bond in cage.get_bonds()
+            ),
+        )
+
+    :class:`.MCHammer` optimized construction
+
+    .. moldoc::
+
+        import moldoc.molecule as molecule
+        import stk
+
+        bb1 = stk.BuildingBlock(
+            smiles='NC1CCCCC1N',
+            functional_groups=[stk.PrimaryAminoFactory()],
+        )
+        bb2 = stk.BuildingBlock(
+            smiles='O=Cc1cc(C=O)cc(C=O)c1',
+            functional_groups=[stk.AldehydeFactory()],
+        )
+        cage = stk.ConstructedMolecule(
+            topology_graph=stk.cage.SixPlusNine(
+                building_blocks=(bb1, bb2),
+                optimizer=stk.MCHammer(),
+            ),
         )
 
         moldoc_display_molecule = molecule.Molecule(

--- a/src/stk/molecular/topology_graphs/cage/two_plus_three/six_plus_nine.py
+++ b/src/stk/molecular/topology_graphs/cage/two_plus_three/six_plus_nine.py
@@ -15,6 +15,42 @@ class SixPlusNine(Cage):
     """
     Represents a cage topology graph.
 
+    .. moldoc::
+
+        import moldoc.molecule as molecule
+        import stk
+
+        bb1 = stk.BuildingBlock(
+            smiles='BrCCBr',
+            functional_groups=[stk.BromoFactory()],
+        )
+        bb2 = stk.BuildingBlock(
+            smiles='Brc1cc(Br)cc(Br)c1',
+            functional_groups=[stk.BromoFactory()],
+        )
+        cage = stk.ConstructedMolecule(
+            topology_graph=stk.cage.SixPlusNine((bb1, bb2)),
+        )
+
+        moldoc_display_molecule = molecule.Molecule(
+            atoms=(
+                molecule.Atom(
+                    atomic_number=atom.get_atomic_number(),
+                    position=position,
+                ) for atom, position in zip(
+                    cage.get_atoms(),
+                    cage.get_position_matrix(),
+                )
+            ),
+            bonds=(
+                molecule.Bond(
+                    atom1_id=bond.get_atom1().get_id(),
+                    atom2_id=bond.get_atom2().get_id(),
+                    order=bond.get_order(),
+                ) for bond in cage.get_bonds()
+            ),
+        )
+
     Nonlinear building blocks with three functional groups are
     required for this topology.
 

--- a/src/stk/molecular/topology_graphs/cage/two_plus_three/twenty_plus_thirty.py
+++ b/src/stk/molecular/topology_graphs/cage/two_plus_three/twenty_plus_thirty.py
@@ -15,6 +15,42 @@ class TwentyPlusThirty(Cage):
     """
     Represents a cage topology graph.
 
+    .. moldoc::
+
+        import moldoc.molecule as molecule
+        import stk
+
+        bb1 = stk.BuildingBlock(
+            smiles='BrCCBr',
+            functional_groups=[stk.BromoFactory()],
+        )
+        bb2 = stk.BuildingBlock(
+            smiles='Brc1cc(Br)cc(Br)c1',
+            functional_groups=[stk.BromoFactory()],
+        )
+        cage = stk.ConstructedMolecule(
+            topology_graph=stk.cage.TwentyPlusThirty((bb1, bb2)),
+        )
+
+        moldoc_display_molecule = molecule.Molecule(
+            atoms=(
+                molecule.Atom(
+                    atomic_number=atom.get_atomic_number(),
+                    position=position,
+                ) for atom, position in zip(
+                    cage.get_atoms(),
+                    cage.get_position_matrix(),
+                )
+            ),
+            bonds=(
+                molecule.Bond(
+                    atom1_id=bond.get_atom1().get_id(),
+                    atom2_id=bond.get_atom2().get_id(),
+                    order=bond.get_order(),
+                ) for bond in cage.get_bonds()
+            ),
+        )
+
     Nonlinear building blocks with three functional groups are
     required for this topology.
 

--- a/src/stk/molecular/topology_graphs/cage/two_plus_three/two_plus_three.py
+++ b/src/stk/molecular/topology_graphs/cage/two_plus_three/two_plus_three.py
@@ -15,6 +15,42 @@ class TwoPlusThree(Cage):
     """
     Represents a cage topology graph.
 
+    .. moldoc::
+
+        import moldoc.molecule as molecule
+        import stk
+
+        bb1 = stk.BuildingBlock(
+            smiles='BrCCBr',
+            functional_groups=[stk.BromoFactory()],
+        )
+        bb2 = stk.BuildingBlock(
+            smiles='Brc1cc(Br)cc(Br)c1',
+            functional_groups=[stk.BromoFactory()],
+        )
+        cage = stk.ConstructedMolecule(
+            topology_graph=stk.cage.TwoPlusThree((bb1, bb2)),
+        )
+
+        moldoc_display_molecule = molecule.Molecule(
+            atoms=(
+                molecule.Atom(
+                    atomic_number=atom.get_atomic_number(),
+                    position=position,
+                ) for atom, position in zip(
+                    cage.get_atoms(),
+                    cage.get_position_matrix(),
+                )
+            ),
+            bonds=(
+                molecule.Bond(
+                    atom1_id=bond.get_atom1().get_id(),
+                    atom2_id=bond.get_atom2().get_id(),
+                    order=bond.get_order(),
+                ) for bond in cage.get_bonds()
+            ),
+        )
+
     Nonlinear building blocks with three functional groups are
     required for this topology.
 

--- a/src/stk/molecular/topology_graphs/cage/two_plus_three/two_plus_three.py
+++ b/src/stk/molecular/topology_graphs/cage/two_plus_three/two_plus_three.py
@@ -15,21 +15,64 @@ class TwoPlusThree(Cage):
     """
     Represents a cage topology graph.
 
+    Unoptimized construction
+
     .. moldoc::
 
         import moldoc.molecule as molecule
         import stk
 
         bb1 = stk.BuildingBlock(
-            smiles='BrCCBr',
-            functional_groups=[stk.BromoFactory()],
+            smiles='NC1CCCCC1N',
+            functional_groups=[stk.PrimaryAminoFactory()],
         )
         bb2 = stk.BuildingBlock(
-            smiles='Brc1cc(Br)cc(Br)c1',
-            functional_groups=[stk.BromoFactory()],
+            smiles='O=Cc1cc(C=O)cc(C=O)c1',
+            functional_groups=[stk.AldehydeFactory()],
         )
         cage = stk.ConstructedMolecule(
             topology_graph=stk.cage.TwoPlusThree((bb1, bb2)),
+        )
+
+        moldoc_display_molecule = molecule.Molecule(
+            atoms=(
+                molecule.Atom(
+                    atomic_number=atom.get_atomic_number(),
+                    position=position,
+                ) for atom, position in zip(
+                    cage.get_atoms(),
+                    cage.get_position_matrix(),
+                )
+            ),
+            bonds=(
+                molecule.Bond(
+                    atom1_id=bond.get_atom1().get_id(),
+                    atom2_id=bond.get_atom2().get_id(),
+                    order=bond.get_order(),
+                ) for bond in cage.get_bonds()
+            ),
+        )
+
+    :class:`.MCHammer` optimized construction
+
+    .. moldoc::
+
+        import moldoc.molecule as molecule
+        import stk
+
+        bb1 = stk.BuildingBlock(
+            smiles='NC1CCCCC1N',
+            functional_groups=[stk.PrimaryAminoFactory()],
+        )
+        bb2 = stk.BuildingBlock(
+            smiles='O=Cc1cc(C=O)cc(C=O)c1',
+            functional_groups=[stk.AldehydeFactory()],
+        )
+        cage = stk.ConstructedMolecule(
+            topology_graph=stk.cage.TwoPlusThree(
+                building_blocks=(bb1, bb2),
+                optimizer=stk.MCHammer(),
+            ),
         )
 
         moldoc_display_molecule = molecule.Molecule(

--- a/src/stk/molecular/topology_graphs/cof/cof.py
+++ b/src/stk/molecular/topology_graphs/cof/cof.py
@@ -96,6 +96,39 @@ class Cof(TopologyGraph):
             topology_graph=stk.cof.Honeycomb((bb1, bb2), (3, 3, 1)),
         )
 
+    .. moldoc::
+
+        import moldoc.molecule as molecule
+        import stk
+
+        bb1 = stk.BuildingBlock('BrCCBr', [stk.BromoFactory()])
+        bb2 = stk.BuildingBlock('BrCC(CBr)CBr', [stk.BromoFactory()])
+        cof = stk.ConstructedMolecule(
+            topology_graph=stk.cof.Honeycomb((bb1, bb2), (3, 3, 1)),
+        )
+        moldoc_display_molecule = molecule.Molecule(
+            atoms=(
+                molecule.Atom(
+                    atomic_number=atom.get_atomic_number(),
+                    position=position,
+                ) for atom, position in zip(
+                    cof.get_atoms(),
+                    cof.get_position_matrix(),
+                )
+            ),
+            bonds=(
+                molecule.Bond(
+                    atom1_id=bond.get_atom1().get_id(),
+                    atom2_id=bond.get_atom2().get_id(),
+                    order=(
+                        1
+                        if bond.get_order() == 9
+                        else bond.get_order()
+                    ),
+                ) for bond in cof.get_bonds()
+            ),
+        )
+
     *Suggested Optimization*
 
     For :class:`.Cof` topologies, it is recommend to use the
@@ -127,6 +160,46 @@ class Cof(TopologyGraph):
                 building_blocks=(bb1, bb2),
                 lattice_size=(3, 3, 1),
                 optimizer=stk.PeriodicCollapser(),
+            ),
+        )
+
+    .. moldoc::
+
+        import moldoc.molecule as molecule
+        import stk
+
+        bb1 = stk.BuildingBlock('BrCCBr', [stk.BromoFactory()])
+        bb2 = stk.BuildingBlock('BrCC(CBr)CBr', [stk.BromoFactory()])
+
+        cof = stk.ConstructedMolecule(
+            topology_graph=stk.cof.Honeycomb(
+                building_blocks=(bb1, bb2),
+                lattice_size=(3, 3, 1),
+                # Setting scale_steps to False tends to lead to a
+                # better structure.
+                optimizer=stk.Collapser(scale_steps=False),
+            ),
+        )
+        moldoc_display_molecule = molecule.Molecule(
+            atoms=(
+                molecule.Atom(
+                    atomic_number=atom.get_atomic_number(),
+                    position=position,
+                ) for atom, position in zip(
+                    cof.get_atoms(),
+                    cof.get_position_matrix(),
+                )
+            ),
+            bonds=(
+                molecule.Bond(
+                    atom1_id=bond.get_atom1().get_id(),
+                    atom2_id=bond.get_atom2().get_id(),
+                    order=(
+                        1
+                        if bond.get_order() == 9
+                        else bond.get_order()
+                    ),
+                ) for bond in cof.get_bonds()
             ),
         )
 

--- a/src/stk/molecular/topology_graphs/cof/hexagonal.py
+++ b/src/stk/molecular/topology_graphs/cof/hexagonal.py
@@ -16,6 +16,42 @@ class Hexagonal(Cof):
     """
     Represents a hexagonal COF topology graph.
 
+    .. moldoc::
+
+        import moldoc.molecule as molecule
+        import stk
+
+        bb1 = stk.BuildingBlock('BrCCBr', [stk.BromoFactory()])
+        bb2 = stk.BuildingBlock(
+            smiles='Brc1c(Br)c(Br)c(Br)c(Br)c1Br',
+            functional_groups=[stk.BromoFactory()],
+        )
+
+        cof = stk.ConstructedMolecule(
+            topology_graph=stk.cof.Hexagonal(
+                building_blocks=(bb1, bb2),
+                lattice_size=(2, 2, 1),
+            ),
+        )
+        moldoc_display_molecule = molecule.Molecule(
+            atoms=(
+                molecule.Atom(
+                    atomic_number=atom.get_atomic_number(),
+                    position=position,
+                ) for atom, position in zip(
+                    cof.get_atoms(),
+                    cof.get_position_matrix(),
+                )
+            ),
+            bonds=(
+                molecule.Bond(
+                    atom1_id=bond.get_atom1().get_id(),
+                    atom2_id=bond.get_atom2().get_id(),
+                    order=bond.get_order(),
+                ) for bond in cof.get_bonds()
+            ),
+        )
+
     Building blocks with six and two functional groups are required
     for this topology graph.
 

--- a/src/stk/molecular/topology_graphs/cof/hexagonal.py
+++ b/src/stk/molecular/topology_graphs/cof/hexagonal.py
@@ -16,6 +16,8 @@ class Hexagonal(Cof):
     """
     Represents a hexagonal COF topology graph.
 
+    Unoptimized construction
+
     .. moldoc::
 
         import moldoc.molecule as molecule
@@ -31,6 +33,45 @@ class Hexagonal(Cof):
             topology_graph=stk.cof.Hexagonal(
                 building_blocks=(bb1, bb2),
                 lattice_size=(2, 2, 1),
+            ),
+        )
+        moldoc_display_molecule = molecule.Molecule(
+            atoms=(
+                molecule.Atom(
+                    atomic_number=atom.get_atomic_number(),
+                    position=position,
+                ) for atom, position in zip(
+                    cof.get_atoms(),
+                    cof.get_position_matrix(),
+                )
+            ),
+            bonds=(
+                molecule.Bond(
+                    atom1_id=bond.get_atom1().get_id(),
+                    atom2_id=bond.get_atom2().get_id(),
+                    order=bond.get_order(),
+                ) for bond in cof.get_bonds()
+            ),
+        )
+
+    ``Collapser(scale_steps=False)`` optimized construction
+
+    .. moldoc::
+
+        import moldoc.molecule as molecule
+        import stk
+
+        bb1 = stk.BuildingBlock('BrCCBr', [stk.BromoFactory()])
+        bb2 = stk.BuildingBlock(
+            smiles='Brc1c(Br)c(Br)c(Br)c(Br)c1Br',
+            functional_groups=[stk.BromoFactory()],
+        )
+
+        cof = stk.ConstructedMolecule(
+            topology_graph=stk.cof.Hexagonal(
+                building_blocks=(bb1, bb2),
+                lattice_size=(2, 2, 1),
+                optimizer=stk.Collapser(scale_steps=False),
             ),
         )
         moldoc_display_molecule = molecule.Molecule(

--- a/src/stk/molecular/topology_graphs/cof/honeycomb.py
+++ b/src/stk/molecular/topology_graphs/cof/honeycomb.py
@@ -16,6 +16,43 @@ class Honeycomb(Cof):
     """
     Represents a honeycomb COF topology graph.
 
+    .. moldoc::
+
+        import moldoc.molecule as molecule
+        import stk
+
+        bb1 = stk.BuildingBlock('BrCCBr', [stk.BromoFactory()])
+        bb2 = stk.BuildingBlock('BrCC(CBr)CBr', [stk.BromoFactory()])
+
+        cof = stk.ConstructedMolecule(
+            topology_graph=stk.cof.Honeycomb(
+                building_blocks=(bb1, bb2),
+                lattice_size=(3, 3, 1),
+            ),
+        )
+        moldoc_display_molecule = molecule.Molecule(
+            atoms=(
+                molecule.Atom(
+                    atomic_number=atom.get_atomic_number(),
+                    position=position,
+                ) for atom, position in zip(
+                    cof.get_atoms(),
+                    cof.get_position_matrix(),
+                )
+            ),
+            bonds=(
+                molecule.Bond(
+                    atom1_id=bond.get_atom1().get_id(),
+                    atom2_id=bond.get_atom2().get_id(),
+                    order=(
+                        1
+                        if bond.get_order() == 9
+                        else bond.get_order()
+                    ),
+                ) for bond in cof.get_bonds()
+            ),
+        )
+
     Building blocks with three and two functional groups are required
     for this topology graph.
 

--- a/src/stk/molecular/topology_graphs/cof/honeycomb.py
+++ b/src/stk/molecular/topology_graphs/cof/honeycomb.py
@@ -16,6 +16,8 @@ class Honeycomb(Cof):
     """
     Represents a honeycomb COF topology graph.
 
+    Unoptimized construction
+
     .. moldoc::
 
         import moldoc.molecule as molecule
@@ -28,6 +30,46 @@ class Honeycomb(Cof):
             topology_graph=stk.cof.Honeycomb(
                 building_blocks=(bb1, bb2),
                 lattice_size=(3, 3, 1),
+            ),
+        )
+        moldoc_display_molecule = molecule.Molecule(
+            atoms=(
+                molecule.Atom(
+                    atomic_number=atom.get_atomic_number(),
+                    position=position,
+                ) for atom, position in zip(
+                    cof.get_atoms(),
+                    cof.get_position_matrix(),
+                )
+            ),
+            bonds=(
+                molecule.Bond(
+                    atom1_id=bond.get_atom1().get_id(),
+                    atom2_id=bond.get_atom2().get_id(),
+                    order=(
+                        1
+                        if bond.get_order() == 9
+                        else bond.get_order()
+                    ),
+                ) for bond in cof.get_bonds()
+            ),
+        )
+
+    ``Collapser(scale_steps=False)`` optimized construction
+
+    .. moldoc::
+
+        import moldoc.molecule as molecule
+        import stk
+
+        bb1 = stk.BuildingBlock('BrCCBr', [stk.BromoFactory()])
+        bb2 = stk.BuildingBlock('BrCC(CBr)CBr', [stk.BromoFactory()])
+
+        cof = stk.ConstructedMolecule(
+            topology_graph=stk.cof.Honeycomb(
+                building_blocks=(bb1, bb2),
+                lattice_size=(3, 3, 1),
+                optimizer=stk.Collapser(scale_steps=False),
             ),
         )
         moldoc_display_molecule = molecule.Molecule(

--- a/src/stk/molecular/topology_graphs/cof/kagome.py
+++ b/src/stk/molecular/topology_graphs/cof/kagome.py
@@ -15,6 +15,52 @@ class Kagome(Cof):
     """
     Represents a kagome COF topology graph.
 
+    .. moldoc::
+
+        import moldoc.molecule as molecule
+        import stk
+
+        cof = stk.ConstructedMolecule(
+            topology_graph=stk.cof.Kagome(
+                building_blocks=(
+                    stk.BuildingBlock(
+                        smiles='BrC1=C(Br)[C+]=N1',
+                        functional_groups=[stk.BromoFactory()],
+                    ),
+                    stk.BuildingBlock(
+                        smiles=(
+                            'Br[C+]1C2(Br)[C+]=N[C+]2[C+](Br)[C+]('
+                            'Br)[C+2]1'
+                        ),
+                        functional_groups=[stk.BromoFactory()],
+                    ),
+                ),
+                lattice_size=(3, 3, 1),
+            ),
+        )
+        moldoc_display_molecule = molecule.Molecule(
+            atoms=(
+                molecule.Atom(
+                    atomic_number=atom.get_atomic_number(),
+                    position=position,
+                ) for atom, position in zip(
+                    cof.get_atoms(),
+                    cof.get_position_matrix(),
+                )
+            ),
+            bonds=(
+                molecule.Bond(
+                    atom1_id=bond.get_atom1().get_id(),
+                    atom2_id=bond.get_atom2().get_id(),
+                    order=(
+                        1
+                        if bond.get_order() == 9
+                        else bond.get_order()
+                    ),
+                ) for bond in cof.get_bonds()
+            ),
+        )
+
     Building blocks with four and two functional groups are required
     for this topology graph.
 

--- a/src/stk/molecular/topology_graphs/cof/kagome.py
+++ b/src/stk/molecular/topology_graphs/cof/kagome.py
@@ -15,6 +15,8 @@ class Kagome(Cof):
     """
     Represents a kagome COF topology graph.
 
+    Unoptimized construction
+
     .. moldoc::
 
         import moldoc.molecule as molecule
@@ -24,14 +26,11 @@ class Kagome(Cof):
             topology_graph=stk.cof.Kagome(
                 building_blocks=(
                     stk.BuildingBlock(
-                        smiles='BrC1=C(Br)[C+]=N1',
+                        smiles='BrCC(Br)',
                         functional_groups=[stk.BromoFactory()],
                     ),
                     stk.BuildingBlock(
-                        smiles=(
-                            'Br[C+]1C2(Br)[C+]=N[C+]2[C+](Br)[C+]('
-                            'Br)[C+2]1'
-                        ),
+                        smiles='BrC1C(Br)CC(Br)C(Br)C1',
                         functional_groups=[stk.BromoFactory()],
                     ),
                 ),
@@ -52,14 +51,53 @@ class Kagome(Cof):
                 molecule.Bond(
                     atom1_id=bond.get_atom1().get_id(),
                     atom2_id=bond.get_atom2().get_id(),
-                    order=(
-                        1
-                        if bond.get_order() == 9
-                        else bond.get_order()
-                    ),
+                    order=bond.get_order(),
                 ) for bond in cof.get_bonds()
             ),
         )
+
+    ``Collapser(scale_steps=False)`` optimized construction
+
+    .. moldoc::
+
+        import moldoc.molecule as molecule
+        import stk
+
+        cof = stk.ConstructedMolecule(
+            topology_graph=stk.cof.Kagome(
+                building_blocks=(
+                    stk.BuildingBlock(
+                        smiles='BrCC(Br)',
+                        functional_groups=[stk.BromoFactory()],
+                    ),
+                    stk.BuildingBlock(
+                        smiles='BrC1C(Br)CC(Br)C(Br)C1',
+                        functional_groups=[stk.BromoFactory()],
+                    ),
+                ),
+                lattice_size=(3, 3, 1),
+                optimizer=stk.Collapser(scale_steps=False),
+            ),
+        )
+        moldoc_display_molecule = molecule.Molecule(
+            atoms=(
+                molecule.Atom(
+                    atomic_number=atom.get_atomic_number(),
+                    position=position,
+                ) for atom, position in zip(
+                    cof.get_atoms(),
+                    cof.get_position_matrix(),
+                )
+            ),
+            bonds=(
+                molecule.Bond(
+                    atom1_id=bond.get_atom1().get_id(),
+                    atom2_id=bond.get_atom2().get_id(),
+                    order=bond.get_order(),
+                ) for bond in cof.get_bonds()
+            ),
+        )
+
 
     Building blocks with four and two functional groups are required
     for this topology graph.

--- a/src/stk/molecular/topology_graphs/cof/linkerless_honeycomb.py
+++ b/src/stk/molecular/topology_graphs/cof/linkerless_honeycomb.py
@@ -15,6 +15,8 @@ class LinkerlessHoneycomb(Cof):
     """
     Represents a honeycomb COF topology graph.
 
+    Unoptimized construction
+
     .. moldoc::
 
         import moldoc.molecule as molecule
@@ -45,14 +47,49 @@ class LinkerlessHoneycomb(Cof):
                 molecule.Bond(
                     atom1_id=bond.get_atom1().get_id(),
                     atom2_id=bond.get_atom2().get_id(),
-                    order=(
-                        1
-                        if bond.get_order() == 9
-                        else bond.get_order()
-                    ),
+                    order=bond.get_order(),
                 ) for bond in cof.get_bonds()
             ),
         )
+
+    ``Collapser(scale_steps=False)`` optimized construction
+
+    .. moldoc::
+
+        import moldoc.molecule as molecule
+        import stk
+
+        cof = stk.ConstructedMolecule(
+            topology_graph=stk.cof.LinkerlessHoneycomb(
+                building_blocks=(
+                    stk.BuildingBlock(
+                        smiles='BrCC(CBr)CBr',
+                        functional_groups=[stk.BromoFactory()],
+                    ),
+                ),
+                lattice_size=(3, 3, 1),
+                optimizer=stk.Collapser(scale_steps=False),
+            ),
+        )
+        moldoc_display_molecule = molecule.Molecule(
+            atoms=(
+                molecule.Atom(
+                    atomic_number=atom.get_atomic_number(),
+                    position=position,
+                ) for atom, position in zip(
+                    cof.get_atoms(),
+                    cof.get_position_matrix(),
+                )
+            ),
+            bonds=(
+                molecule.Bond(
+                    atom1_id=bond.get_atom1().get_id(),
+                    atom2_id=bond.get_atom2().get_id(),
+                    order=bond.get_order(),
+                ) for bond in cof.get_bonds()
+            ),
+        )
+
 
     Building blocks with three functional groups are required
     for this topology graph.

--- a/src/stk/molecular/topology_graphs/cof/linkerless_honeycomb.py
+++ b/src/stk/molecular/topology_graphs/cof/linkerless_honeycomb.py
@@ -15,6 +15,45 @@ class LinkerlessHoneycomb(Cof):
     """
     Represents a honeycomb COF topology graph.
 
+    .. moldoc::
+
+        import moldoc.molecule as molecule
+        import stk
+
+        cof = stk.ConstructedMolecule(
+            topology_graph=stk.cof.LinkerlessHoneycomb(
+                building_blocks=(
+                    stk.BuildingBlock(
+                        smiles='BrCC(CBr)CBr',
+                        functional_groups=[stk.BromoFactory()],
+                    ),
+                ),
+                lattice_size=(3, 3, 1),
+            ),
+        )
+        moldoc_display_molecule = molecule.Molecule(
+            atoms=(
+                molecule.Atom(
+                    atomic_number=atom.get_atomic_number(),
+                    position=position,
+                ) for atom, position in zip(
+                    cof.get_atoms(),
+                    cof.get_position_matrix(),
+                )
+            ),
+            bonds=(
+                molecule.Bond(
+                    atom1_id=bond.get_atom1().get_id(),
+                    atom2_id=bond.get_atom2().get_id(),
+                    order=(
+                        1
+                        if bond.get_order() == 9
+                        else bond.get_order()
+                    ),
+                ) for bond in cof.get_bonds()
+            ),
+        )
+
     Building blocks with three functional groups are required
     for this topology graph.
 

--- a/src/stk/molecular/topology_graphs/cof/periodic_hexagonal.py
+++ b/src/stk/molecular/topology_graphs/cof/periodic_hexagonal.py
@@ -18,6 +18,43 @@ class PeriodicHexagonal(Cof):
     """
     Represents a periodic hexagonal COF topology graph.
 
+    .. moldoc::
+
+        import moldoc.molecule as molecule
+        import stk
+
+        bb1 = stk.BuildingBlock('BrCCBr', [stk.BromoFactory()])
+        bb2 = stk.BuildingBlock(
+            smiles='Brc1c(Br)c(Br)c(Br)c(Br)c1Br',
+            functional_groups=[stk.BromoFactory()],
+        )
+
+        cof = stk.ConstructedMolecule(
+            topology_graph=stk.cof.PeriodicHexagonal(
+                building_blocks=(bb1, bb2),
+                lattice_size=(2, 2, 1),
+            ),
+        )
+        moldoc_display_molecule = molecule.Molecule(
+            atoms=(
+                molecule.Atom(
+                    atomic_number=atom.get_atomic_number(),
+                    position=position,
+                ) for atom, position in zip(
+                    cof.get_atoms(),
+                    cof.get_position_matrix(),
+                )
+            ),
+            bonds=(
+                molecule.Bond(
+                    atom1_id=bond.get_atom1().get_id(),
+                    atom2_id=bond.get_atom2().get_id(),
+                    order=bond.get_order(),
+                ) for bond in cof.get_bonds()
+                if all(p == 0 for p in bond.get_periodicity())
+            ),
+        )
+
     Building blocks with six and two functional groups are required
     for this topology graph.
 

--- a/src/stk/molecular/topology_graphs/cof/periodic_hexagonal.py
+++ b/src/stk/molecular/topology_graphs/cof/periodic_hexagonal.py
@@ -18,6 +18,8 @@ class PeriodicHexagonal(Cof):
     """
     Represents a periodic hexagonal COF topology graph.
 
+    Unoptimzed construction
+
     .. moldoc::
 
         import moldoc.molecule as molecule
@@ -33,6 +35,46 @@ class PeriodicHexagonal(Cof):
             topology_graph=stk.cof.PeriodicHexagonal(
                 building_blocks=(bb1, bb2),
                 lattice_size=(2, 2, 1),
+            ),
+        )
+        moldoc_display_molecule = molecule.Molecule(
+            atoms=(
+                molecule.Atom(
+                    atomic_number=atom.get_atomic_number(),
+                    position=position,
+                ) for atom, position in zip(
+                    cof.get_atoms(),
+                    cof.get_position_matrix(),
+                )
+            ),
+            bonds=(
+                molecule.Bond(
+                    atom1_id=bond.get_atom1().get_id(),
+                    atom2_id=bond.get_atom2().get_id(),
+                    order=bond.get_order(),
+                ) for bond in cof.get_bonds()
+                if all(p == 0 for p in bond.get_periodicity())
+            ),
+        )
+
+    ``Collapser(scale_steps=False)`` optimized construction
+
+    .. moldoc::
+
+        import moldoc.molecule as molecule
+        import stk
+
+        bb1 = stk.BuildingBlock('BrCCBr', [stk.BromoFactory()])
+        bb2 = stk.BuildingBlock(
+            smiles='Brc1c(Br)c(Br)c(Br)c(Br)c1Br',
+            functional_groups=[stk.BromoFactory()],
+        )
+
+        cof = stk.ConstructedMolecule(
+            topology_graph=stk.cof.PeriodicHexagonal(
+                building_blocks=(bb1, bb2),
+                lattice_size=(2, 2, 1),
+                optimizer=stk.Collapser(scale_steps=False),
             ),
         )
         moldoc_display_molecule = molecule.Molecule(

--- a/src/stk/molecular/topology_graphs/cof/periodic_honeycomb.py
+++ b/src/stk/molecular/topology_graphs/cof/periodic_honeycomb.py
@@ -18,6 +18,44 @@ class PeriodicHoneycomb(Cof):
     """
     Represents a periodic honeycomb COF topology graph.
 
+    .. moldoc::
+
+        import moldoc.molecule as molecule
+        import stk
+
+        bb1 = stk.BuildingBlock('BrCCBr', [stk.BromoFactory()])
+        bb2 = stk.BuildingBlock('BrCC(CBr)CBr', [stk.BromoFactory()])
+
+        cof = stk.ConstructedMolecule(
+            topology_graph=stk.cof.PeriodicHoneycomb(
+                building_blocks=(bb1, bb2),
+                lattice_size=(3, 3, 1),
+            ),
+        )
+        moldoc_display_molecule = molecule.Molecule(
+            atoms=(
+                molecule.Atom(
+                    atomic_number=atom.get_atomic_number(),
+                    position=position,
+                ) for atom, position in zip(
+                    cof.get_atoms(),
+                    cof.get_position_matrix(),
+                )
+            ),
+            bonds=(
+                molecule.Bond(
+                    atom1_id=bond.get_atom1().get_id(),
+                    atom2_id=bond.get_atom2().get_id(),
+                    order=(
+                        1
+                        if bond.get_order() == 9
+                        else bond.get_order()
+                    ),
+                ) for bond in cof.get_bonds()
+                if all(p == 0 for p in bond.get_periodicity())
+            ),
+        )
+
     Building blocks with three and two functional groups are required
     for this topology graph.
 

--- a/src/stk/molecular/topology_graphs/cof/periodic_honeycomb.py
+++ b/src/stk/molecular/topology_graphs/cof/periodic_honeycomb.py
@@ -18,6 +18,8 @@ class PeriodicHoneycomb(Cof):
     """
     Represents a periodic honeycomb COF topology graph.
 
+    Unoptimized construction
+
     .. moldoc::
 
         import moldoc.molecule as molecule
@@ -30,6 +32,47 @@ class PeriodicHoneycomb(Cof):
             topology_graph=stk.cof.PeriodicHoneycomb(
                 building_blocks=(bb1, bb2),
                 lattice_size=(3, 3, 1),
+            ),
+        )
+        moldoc_display_molecule = molecule.Molecule(
+            atoms=(
+                molecule.Atom(
+                    atomic_number=atom.get_atomic_number(),
+                    position=position,
+                ) for atom, position in zip(
+                    cof.get_atoms(),
+                    cof.get_position_matrix(),
+                )
+            ),
+            bonds=(
+                molecule.Bond(
+                    atom1_id=bond.get_atom1().get_id(),
+                    atom2_id=bond.get_atom2().get_id(),
+                    order=(
+                        1
+                        if bond.get_order() == 9
+                        else bond.get_order()
+                    ),
+                ) for bond in cof.get_bonds()
+                if all(p == 0 for p in bond.get_periodicity())
+            ),
+        )
+
+    ``Collapser(scale_steps=False)`` optimized construction
+
+    .. moldoc::
+
+        import moldoc.molecule as molecule
+        import stk
+
+        bb1 = stk.BuildingBlock('BrCCBr', [stk.BromoFactory()])
+        bb2 = stk.BuildingBlock('BrCC(CBr)CBr', [stk.BromoFactory()])
+
+        cof = stk.ConstructedMolecule(
+            topology_graph=stk.cof.PeriodicHoneycomb(
+                building_blocks=(bb1, bb2),
+                lattice_size=(3, 3, 1),
+                optimizer=stk.Collapser(scale_steps=False),
             ),
         )
         moldoc_display_molecule = molecule.Molecule(

--- a/src/stk/molecular/topology_graphs/cof/periodic_kagome.py
+++ b/src/stk/molecular/topology_graphs/cof/periodic_kagome.py
@@ -18,6 +18,53 @@ class PeriodicKagome(Cof):
     """
     Represents a periodic kagome COF topology graph.
 
+    .. moldoc::
+
+        import moldoc.molecule as molecule
+        import stk
+
+        cof = stk.ConstructedMolecule(
+            topology_graph=stk.cof.PeriodicKagome(
+                building_blocks=(
+                    stk.BuildingBlock(
+                        smiles='BrC1=C(Br)[C+]=N1',
+                        functional_groups=[stk.BromoFactory()],
+                    ),
+                    stk.BuildingBlock(
+                        smiles=(
+                            'Br[C+]1C2(Br)[C+]=N[C+]2[C+](Br)[C+]('
+                            'Br)[C+2]1'
+                        ),
+                        functional_groups=[stk.BromoFactory()],
+                    ),
+                ),
+                lattice_size=(3, 3, 1),
+            ),
+        )
+        moldoc_display_molecule = molecule.Molecule(
+            atoms=(
+                molecule.Atom(
+                    atomic_number=atom.get_atomic_number(),
+                    position=position,
+                ) for atom, position in zip(
+                    cof.get_atoms(),
+                    cof.get_position_matrix(),
+                )
+            ),
+            bonds=(
+                molecule.Bond(
+                    atom1_id=bond.get_atom1().get_id(),
+                    atom2_id=bond.get_atom2().get_id(),
+                    order=(
+                        1
+                        if bond.get_order() == 9
+                        else bond.get_order()
+                    ),
+                ) for bond in cof.get_bonds()
+                if all(p == 0 for p in bond.get_periodicity())
+            ),
+        )
+
     Building blocks with four and two functional groups are required
     for this topology graph.
 

--- a/src/stk/molecular/topology_graphs/cof/periodic_kagome.py
+++ b/src/stk/molecular/topology_graphs/cof/periodic_kagome.py
@@ -18,6 +18,8 @@ class PeriodicKagome(Cof):
     """
     Represents a periodic kagome COF topology graph.
 
+    Unoptimized construction
+
     .. moldoc::
 
         import moldoc.molecule as molecule
@@ -27,18 +29,62 @@ class PeriodicKagome(Cof):
             topology_graph=stk.cof.PeriodicKagome(
                 building_blocks=(
                     stk.BuildingBlock(
-                        smiles='BrC1=C(Br)[C+]=N1',
+                        smiles='BrCC(Br)',
                         functional_groups=[stk.BromoFactory()],
                     ),
                     stk.BuildingBlock(
-                        smiles=(
-                            'Br[C+]1C2(Br)[C+]=N[C+]2[C+](Br)[C+]('
-                            'Br)[C+2]1'
-                        ),
+                        smiles='BrC1C(Br)CC(Br)C(Br)C1',
                         functional_groups=[stk.BromoFactory()],
                     ),
                 ),
                 lattice_size=(3, 3, 1),
+            ),
+        )
+        moldoc_display_molecule = molecule.Molecule(
+            atoms=(
+                molecule.Atom(
+                    atomic_number=atom.get_atomic_number(),
+                    position=position,
+                ) for atom, position in zip(
+                    cof.get_atoms(),
+                    cof.get_position_matrix(),
+                )
+            ),
+            bonds=(
+                molecule.Bond(
+                    atom1_id=bond.get_atom1().get_id(),
+                    atom2_id=bond.get_atom2().get_id(),
+                    order=(
+                        1
+                        if bond.get_order() == 9
+                        else bond.get_order()
+                    ),
+                ) for bond in cof.get_bonds()
+                if all(p == 0 for p in bond.get_periodicity())
+            ),
+        )
+
+    ``Collapser(scale_steps=False)`` optimized construction
+
+    .. moldoc::
+
+        import moldoc.molecule as molecule
+        import stk
+
+        cof = stk.ConstructedMolecule(
+            topology_graph=stk.cof.PeriodicKagome(
+                building_blocks=(
+                    stk.BuildingBlock(
+                        smiles='BrCC(Br)',
+                        functional_groups=[stk.BromoFactory()],
+                    ),
+                    stk.BuildingBlock(
+                        smiles='BrC1C(Br)CC(Br)C(Br)C1',
+                        functional_groups=[stk.BromoFactory()],
+                    ),
+                ),
+                lattice_size=(3, 3, 1),
+                optimizer=stk.Collapser(scale_steps=False),
             ),
         )
         moldoc_display_molecule = molecule.Molecule(

--- a/src/stk/molecular/topology_graphs/cof/periodic_linkerless_honeycomb.py
+++ b/src/stk/molecular/topology_graphs/cof/periodic_linkerless_honeycomb.py
@@ -18,6 +18,8 @@ class PeriodicLinkerlessHoneycomb(Cof):
     """
     Represents a periodic honeycomb COF topology graph.
 
+    Unoptimized construction
+
     .. moldoc::
 
         import moldoc.molecule as molecule
@@ -48,11 +50,46 @@ class PeriodicLinkerlessHoneycomb(Cof):
                 molecule.Bond(
                     atom1_id=bond.get_atom1().get_id(),
                     atom2_id=bond.get_atom2().get_id(),
-                    order=(
-                        1
-                        if bond.get_order() == 9
-                        else bond.get_order()
+                    order=bond.get_order(),
+                ) for bond in cof.get_bonds()
+                if all(p == 0 for p in bond.get_periodicity())
+            ),
+        )
+
+    ``Collapser(scale_steps=False)`` optimized construction
+
+    .. moldoc::
+
+        import moldoc.molecule as molecule
+        import stk
+
+        cof = stk.ConstructedMolecule(
+            topology_graph=stk.cof.PeriodicLinkerlessHoneycomb(
+                building_blocks=(
+                    stk.BuildingBlock(
+                        smiles='BrCC(CBr)CBr',
+                        functional_groups=[stk.BromoFactory()],
                     ),
+                ),
+                lattice_size=(3, 3, 1),
+                optimizer=stk.Collapser(scale_steps=False),
+            ),
+        )
+        moldoc_display_molecule = molecule.Molecule(
+            atoms=(
+                molecule.Atom(
+                    atomic_number=atom.get_atomic_number(),
+                    position=position,
+                ) for atom, position in zip(
+                    cof.get_atoms(),
+                    cof.get_position_matrix(),
+                )
+            ),
+            bonds=(
+                molecule.Bond(
+                    atom1_id=bond.get_atom1().get_id(),
+                    atom2_id=bond.get_atom2().get_id(),
+                    order=bond.get_order(),
                 ) for bond in cof.get_bonds()
                 if all(p == 0 for p in bond.get_periodicity())
             ),

--- a/src/stk/molecular/topology_graphs/cof/periodic_linkerless_honeycomb.py
+++ b/src/stk/molecular/topology_graphs/cof/periodic_linkerless_honeycomb.py
@@ -18,6 +18,46 @@ class PeriodicLinkerlessHoneycomb(Cof):
     """
     Represents a periodic honeycomb COF topology graph.
 
+    .. moldoc::
+
+        import moldoc.molecule as molecule
+        import stk
+
+        cof = stk.ConstructedMolecule(
+            topology_graph=stk.cof.PeriodicLinkerlessHoneycomb(
+                building_blocks=(
+                    stk.BuildingBlock(
+                        smiles='BrCC(CBr)CBr',
+                        functional_groups=[stk.BromoFactory()],
+                    ),
+                ),
+                lattice_size=(3, 3, 1),
+            ),
+        )
+        moldoc_display_molecule = molecule.Molecule(
+            atoms=(
+                molecule.Atom(
+                    atomic_number=atom.get_atomic_number(),
+                    position=position,
+                ) for atom, position in zip(
+                    cof.get_atoms(),
+                    cof.get_position_matrix(),
+                )
+            ),
+            bonds=(
+                molecule.Bond(
+                    atom1_id=bond.get_atom1().get_id(),
+                    atom2_id=bond.get_atom2().get_id(),
+                    order=(
+                        1
+                        if bond.get_order() == 9
+                        else bond.get_order()
+                    ),
+                ) for bond in cof.get_bonds()
+                if all(p == 0 for p in bond.get_periodicity())
+            ),
+        )
+
     Building blocks with three functional groups are required
     for this topology graph.
 

--- a/src/stk/molecular/topology_graphs/cof/periodic_square.py
+++ b/src/stk/molecular/topology_graphs/cof/periodic_square.py
@@ -17,6 +17,8 @@ class PeriodicSquare(Cof):
     """
     Represents a periodic square COF topology graph.
 
+    Unoptimized construction
+
     .. moldoc::
 
         import moldoc.molecule as molecule
@@ -26,11 +28,11 @@ class PeriodicSquare(Cof):
             topology_graph=stk.cof.PeriodicSquare(
                 building_blocks=(
                     stk.BuildingBlock(
-                        smiles='BrC1=C(Br)[C+]=N1',
+                        smiles='BrCC(Br)',
                         functional_groups=[stk.BromoFactory()],
                     ),
                     stk.BuildingBlock(
-                        smiles='BrC1=C(Br)C(F)(Br)[C+]1Br',
+                        smiles='BrC1=C(Br)C(Br)=C1Br',
                         functional_groups=[stk.BromoFactory()],
                     ),
                 ),
@@ -51,11 +53,50 @@ class PeriodicSquare(Cof):
                 molecule.Bond(
                     atom1_id=bond.get_atom1().get_id(),
                     atom2_id=bond.get_atom2().get_id(),
-                    order=(
-                        1
-                        if bond.get_order() == 9
-                        else bond.get_order()
+                    order=bond.get_order(),
+                ) for bond in cof.get_bonds()
+                if all(p == 0 for p in bond.get_periodicity())
+            ),
+        )
+
+    ``Collapser(scale_steps=False)`` optimized construction
+
+    .. moldoc::
+
+        import moldoc.molecule as molecule
+        import stk
+
+        cof = stk.ConstructedMolecule(
+            topology_graph=stk.cof.PeriodicSquare(
+                building_blocks=(
+                    stk.BuildingBlock(
+                        smiles='BrCCBr',
+                        functional_groups=[stk.BromoFactory()],
                     ),
+                    stk.BuildingBlock(
+                        smiles='BrC1=C(Br)C(Br)=C1Br',
+                        functional_groups=[stk.BromoFactory()],
+                    ),
+                ),
+                lattice_size=(3, 3, 1),
+                optimizer=stk.Collapser(scale_steps=False),
+            ),
+        )
+        moldoc_display_molecule = molecule.Molecule(
+            atoms=(
+                molecule.Atom(
+                    atomic_number=atom.get_atomic_number(),
+                    position=position,
+                ) for atom, position in zip(
+                    cof.get_atoms(),
+                    cof.get_position_matrix(),
+                )
+            ),
+            bonds=(
+                molecule.Bond(
+                    atom1_id=bond.get_atom1().get_id(),
+                    atom2_id=bond.get_atom2().get_id(),
+                    order=bond.get_order(),
                 ) for bond in cof.get_bonds()
                 if all(p == 0 for p in bond.get_periodicity())
             ),

--- a/src/stk/molecular/topology_graphs/cof/periodic_square.py
+++ b/src/stk/molecular/topology_graphs/cof/periodic_square.py
@@ -17,6 +17,50 @@ class PeriodicSquare(Cof):
     """
     Represents a periodic square COF topology graph.
 
+    .. moldoc::
+
+        import moldoc.molecule as molecule
+        import stk
+
+        cof = stk.ConstructedMolecule(
+            topology_graph=stk.cof.PeriodicSquare(
+                building_blocks=(
+                    stk.BuildingBlock(
+                        smiles='BrC1=C(Br)[C+]=N1',
+                        functional_groups=[stk.BromoFactory()],
+                    ),
+                    stk.BuildingBlock(
+                        smiles='BrC1=C(Br)C(F)(Br)[C+]1Br',
+                        functional_groups=[stk.BromoFactory()],
+                    ),
+                ),
+                lattice_size=(3, 3, 1),
+            ),
+        )
+        moldoc_display_molecule = molecule.Molecule(
+            atoms=(
+                molecule.Atom(
+                    atomic_number=atom.get_atomic_number(),
+                    position=position,
+                ) for atom, position in zip(
+                    cof.get_atoms(),
+                    cof.get_position_matrix(),
+                )
+            ),
+            bonds=(
+                molecule.Bond(
+                    atom1_id=bond.get_atom1().get_id(),
+                    atom2_id=bond.get_atom2().get_id(),
+                    order=(
+                        1
+                        if bond.get_order() == 9
+                        else bond.get_order()
+                    ),
+                ) for bond in cof.get_bonds()
+                if all(p == 0 for p in bond.get_periodicity())
+            ),
+        )
+
     Building blocks with four and two functional groups are required
     for this topology graph.
 

--- a/src/stk/molecular/topology_graphs/cof/square.py
+++ b/src/stk/molecular/topology_graphs/cof/square.py
@@ -16,20 +16,22 @@ class Square(Cof):
     """
     Represents a sqaure COF topology graph.
 
+    Unoptimized construction
+
     .. moldoc::
 
         import moldoc.molecule as molecule
         import stk
 
         cof = stk.ConstructedMolecule(
-            topology_graph=stk.cof.Square(
+            topology_graph=stk.cof.PeriodicSquare(
                 building_blocks=(
                     stk.BuildingBlock(
-                        smiles='BrC1=C(Br)[C+]=N1',
+                        smiles='BrCC(Br)',
                         functional_groups=[stk.BromoFactory()],
                     ),
                     stk.BuildingBlock(
-                        smiles='BrC1=C(Br)C(F)(Br)[C+]1Br',
+                        smiles='BrC1=C(Br)C(Br)=C1Br',
                         functional_groups=[stk.BromoFactory()],
                     ),
                 ),
@@ -50,11 +52,50 @@ class Square(Cof):
                 molecule.Bond(
                     atom1_id=bond.get_atom1().get_id(),
                     atom2_id=bond.get_atom2().get_id(),
-                    order=(
-                        1
-                        if bond.get_order() == 9
-                        else bond.get_order()
+                    order=bond.get_order(),
+                ) for bond in cof.get_bonds()
+                if all(p == 0 for p in bond.get_periodicity())
+            ),
+        )
+
+    ``Collapser(scale_steps=False)`` optimized construction
+
+    .. moldoc::
+
+        import moldoc.molecule as molecule
+        import stk
+
+        cof = stk.ConstructedMolecule(
+            topology_graph=stk.cof.PeriodicSquare(
+                building_blocks=(
+                    stk.BuildingBlock(
+                        smiles='BrCC(Br)',
+                        functional_groups=[stk.BromoFactory()],
                     ),
+                    stk.BuildingBlock(
+                        smiles='BrC1=C(Br)C(Br)=C1Br',
+                        functional_groups=[stk.BromoFactory()],
+                    ),
+                ),
+                lattice_size=(3, 3, 1),
+                optimizer=stk.Collapser(scale_steps=False),
+            ),
+        )
+        moldoc_display_molecule = molecule.Molecule(
+            atoms=(
+                molecule.Atom(
+                    atomic_number=atom.get_atomic_number(),
+                    position=position,
+                ) for atom, position in zip(
+                    cof.get_atoms(),
+                    cof.get_position_matrix(),
+                )
+            ),
+            bonds=(
+                molecule.Bond(
+                    atom1_id=bond.get_atom1().get_id(),
+                    atom2_id=bond.get_atom2().get_id(),
+                    order=bond.get_order(),
                 ) for bond in cof.get_bonds()
                 if all(p == 0 for p in bond.get_periodicity())
             ),

--- a/src/stk/molecular/topology_graphs/cof/square.py
+++ b/src/stk/molecular/topology_graphs/cof/square.py
@@ -16,6 +16,50 @@ class Square(Cof):
     """
     Represents a sqaure COF topology graph.
 
+    .. moldoc::
+
+        import moldoc.molecule as molecule
+        import stk
+
+        cof = stk.ConstructedMolecule(
+            topology_graph=stk.cof.Square(
+                building_blocks=(
+                    stk.BuildingBlock(
+                        smiles='BrC1=C(Br)[C+]=N1',
+                        functional_groups=[stk.BromoFactory()],
+                    ),
+                    stk.BuildingBlock(
+                        smiles='BrC1=C(Br)C(F)(Br)[C+]1Br',
+                        functional_groups=[stk.BromoFactory()],
+                    ),
+                ),
+                lattice_size=(3, 3, 1),
+            ),
+        )
+        moldoc_display_molecule = molecule.Molecule(
+            atoms=(
+                molecule.Atom(
+                    atomic_number=atom.get_atomic_number(),
+                    position=position,
+                ) for atom, position in zip(
+                    cof.get_atoms(),
+                    cof.get_position_matrix(),
+                )
+            ),
+            bonds=(
+                molecule.Bond(
+                    atom1_id=bond.get_atom1().get_id(),
+                    atom2_id=bond.get_atom2().get_id(),
+                    order=(
+                        1
+                        if bond.get_order() == 9
+                        else bond.get_order()
+                    ),
+                ) for bond in cof.get_bonds()
+                if all(p == 0 for p in bond.get_periodicity())
+            ),
+        )
+
     Building blocks with four and two functional groups are required
     for this topology graph.
 

--- a/src/stk/molecular/topology_graphs/host_guest/complex.py
+++ b/src/stk/molecular/topology_graphs/host_guest/complex.py
@@ -117,6 +117,7 @@ class Complex(TopologyGraph):
     Host and guest building blocks do not require functional groups.
 
     Examples:
+
         *Construction*
 
         You can use :class:`.ConstructedMolecule` instances as the
@@ -131,14 +132,17 @@ class Complex(TopologyGraph):
                 topology_graph=stk.cage.FourPlusSix(
                     building_blocks=(
                         stk.BuildingBlock(
-                            smiles='BrCCBr',
-                            functional_groups=[stk.BromoFactory()],
+                            smiles='NC1CCCCC1N',
+                            functional_groups=[
+                                stk.PrimaryAminoFactory(),
+                            ],
                         ),
                         stk.BuildingBlock(
-                            smiles='BrCC(Br)CBr',
-                            functional_groups=[stk.BromoFactory()],
+                            smiles='O=Cc1cc(C=O)cc(C=O)c1',
+                            functional_groups=[stk.AldehydeFactory()],
                         ),
                     ),
+                    optimizer=stk.MCHammer(),
                 ),
             )
             complex = stk.ConstructedMolecule(
@@ -147,6 +151,56 @@ class Complex(TopologyGraph):
                     guests=stk.host_guest.Guest(
                         building_block=stk.BuildingBlock('[Br][Br]'),
                     ),
+                ),
+            )
+
+        .. moldoc::
+
+            import moldoc.molecule as molecule
+            import stk
+
+            host = stk.ConstructedMolecule(
+                topology_graph=stk.cage.FourPlusSix(
+                    building_blocks=(
+                        stk.BuildingBlock(
+                            smiles='NC1CCCCC1N',
+                            functional_groups=[
+                                stk.PrimaryAminoFactory(),
+                            ],
+                        ),
+                        stk.BuildingBlock(
+                            smiles='O=Cc1cc(C=O)cc(C=O)c1',
+                            functional_groups=[stk.AldehydeFactory()],
+                        ),
+                    ),
+                    optimizer=stk.MCHammer(),
+                ),
+            )
+            complex = stk.ConstructedMolecule(
+                topology_graph=stk.host_guest.Complex(
+                    host=stk.BuildingBlock.init_from_molecule(host),
+                    guests=stk.host_guest.Guest(
+                        building_block=stk.BuildingBlock('[Br][Br]'),
+                    ),
+                ),
+            )
+
+            moldoc_display_molecule = molecule.Molecule(
+                atoms=(
+                    molecule.Atom(
+                        atomic_number=atom.get_atomic_number(),
+                        position=position,
+                    ) for atom, position in zip(
+                        complex.get_atoms(),
+                        complex.get_position_matrix(),
+                    )
+                ),
+                bonds=(
+                    molecule.Bond(
+                        atom1_id=bond.get_atom1().get_id(),
+                        atom2_id=bond.get_atom2().get_id(),
+                        order=bond.get_order(),
+                    ) for bond in complex.get_bonds()
                 ),
             )
 
@@ -160,18 +214,22 @@ class Complex(TopologyGraph):
                 topology_graph=stk.cage.FourPlusSix(
                     building_blocks=(
                         stk.BuildingBlock(
-                            smiles='BrCCBr',
-                            functional_groups=[stk.BromoFactory()],
+                            smiles='NC1CCCCC1N',
+                            functional_groups=[
+                                stk.PrimaryAminoFactory(),
+                            ],
                         ),
                         stk.BuildingBlock(
-                            smiles='BrCC(Br)CBr',
-                            functional_groups=[stk.BromoFactory()],
+                            smiles='O=Cc1cc(C=O)cc(C=O)c1',
+                            functional_groups=[stk.AldehydeFactory()],
                         ),
                     ),
+                    optimizer=stk.MCHammer(),
                 ),
             )
             guest1 = stk.host_guest.Guest(
-                building_block=stk.BuildingBlock('c1ccccc1'),
+                building_block=stk.BuildingBlock('BrBr'),
+                displacement=(0., 3., 0.),
             )
             guest2 = stk.host_guest.Guest(
                 building_block=stk.BuildingBlock('C1CCCC1'),
@@ -181,6 +239,62 @@ class Complex(TopologyGraph):
                 topology_graph=stk.host_guest.Complex(
                     host=stk.BuildingBlock.init_from_molecule(host),
                     guests=(guest1, guest2),
+                ),
+            )
+
+        .. moldoc::
+
+            import moldoc.molecule as molecule
+            import stk
+
+            host = stk.ConstructedMolecule(
+                topology_graph=stk.cage.FourPlusSix(
+                    building_blocks=(
+                        stk.BuildingBlock(
+                            smiles='NC1CCCCC1N',
+                            functional_groups=[
+                                stk.PrimaryAminoFactory(),
+                            ],
+                        ),
+                        stk.BuildingBlock(
+                            smiles='O=Cc1cc(C=O)cc(C=O)c1',
+                            functional_groups=[stk.AldehydeFactory()],
+                        ),
+                    ),
+                    optimizer=stk.MCHammer(),
+                ),
+            )
+            guest1 = stk.host_guest.Guest(
+                building_block=stk.BuildingBlock('BrBr'),
+                displacement=(0., 3., 0.),
+            )
+            guest2 = stk.host_guest.Guest(
+                building_block=stk.BuildingBlock('C1CCCC1'),
+            )
+
+            complex = stk.ConstructedMolecule(
+                topology_graph=stk.host_guest.Complex(
+                    host=stk.BuildingBlock.init_from_molecule(host),
+                    guests=(guest1, guest2),
+                ),
+            )
+
+            moldoc_display_molecule = molecule.Molecule(
+                atoms=(
+                    molecule.Atom(
+                        atomic_number=atom.get_atomic_number(),
+                        position=position,
+                    ) for atom, position in zip(
+                        complex.get_atoms(),
+                        complex.get_position_matrix(),
+                    )
+                ),
+                bonds=(
+                    molecule.Bond(
+                        atom1_id=bond.get_atom1().get_id(),
+                        atom2_id=bond.get_atom2().get_id(),
+                        order=bond.get_order(),
+                    ) for bond in complex.get_bonds()
                 ),
             )
 
@@ -195,27 +309,93 @@ class Complex(TopologyGraph):
 
             import stk
 
-            bb1 = stk.BuildingBlock(
-                smiles='NCCN',
-                functional_groups=[stk.PrimaryAminoFactory()],
-            )
-            bb2 = stk.BuildingBlock(
-                smiles='O=CC(C=O)C=O',
-                functional_groups=[stk.AldehydeFactory()],
-            )
-            guest = stk.host_guest.Guest(stk.BuildingBlock('c1ccccc1'))
-            cage = stk.ConstructedMolecule(
+            host = stk.ConstructedMolecule(
                 topology_graph=stk.cage.FourPlusSix(
-                    building_blocks=(bb1, bb2),
+                    building_blocks=(
+                        stk.BuildingBlock(
+                            smiles='NC1CCCCC1N',
+                            functional_groups=[
+                                stk.PrimaryAminoFactory(),
+                            ],
+                        ),
+                        stk.BuildingBlock(
+                            smiles='O=Cc1cc(C=O)cc(C=O)c1',
+                            functional_groups=[stk.AldehydeFactory()],
+                        ),
+                    ),
                     optimizer=stk.MCHammer(),
                 ),
+            )
+            guest1 = stk.host_guest.Guest(
+                building_block=stk.BuildingBlock('BrBr'),
+                displacement=(0., 3., 0.),
+            )
+            guest2 = stk.host_guest.Guest(
+                building_block=stk.BuildingBlock('C1CCCC1'),
             )
 
             complex = stk.ConstructedMolecule(
                 topology_graph=stk.host_guest.Complex(
-                    host=stk.BuildingBlock.init_from_molecule(cage),
-                    guests=guest,
+                    host=stk.BuildingBlock.init_from_molecule(host),
+                    guests=(guest1, guest2),
                     optimizer=stk.Spinner(),
+                ),
+            )
+
+        .. moldoc::
+
+            import moldoc.molecule as molecule
+            import stk
+
+            host = stk.ConstructedMolecule(
+                topology_graph=stk.cage.FourPlusSix(
+                    building_blocks=(
+                        stk.BuildingBlock(
+                            smiles='NC1CCCCC1N',
+                            functional_groups=[
+                                stk.PrimaryAminoFactory(),
+                            ],
+                        ),
+                        stk.BuildingBlock(
+                            smiles='O=Cc1cc(C=O)cc(C=O)c1',
+                            functional_groups=[stk.AldehydeFactory()],
+                        ),
+                    ),
+                    optimizer=stk.MCHammer(),
+                ),
+            )
+            guest1 = stk.host_guest.Guest(
+                building_block=stk.BuildingBlock('BrBr'),
+                displacement=(0., 3., 0.),
+            )
+            guest2 = stk.host_guest.Guest(
+                building_block=stk.BuildingBlock('C1CCCC1'),
+            )
+
+            complex = stk.ConstructedMolecule(
+                topology_graph=stk.host_guest.Complex(
+                    host=stk.BuildingBlock.init_from_molecule(host),
+                    guests=(guest1, guest2),
+                    optimizer=stk.Spinner(),
+                ),
+            )
+
+            moldoc_display_molecule = molecule.Molecule(
+                atoms=(
+                    molecule.Atom(
+                        atomic_number=atom.get_atomic_number(),
+                        position=position,
+                    ) for atom, position in zip(
+                        complex.get_atoms(),
+                        complex.get_position_matrix(),
+                    )
+                ),
+                bonds=(
+                    molecule.Bond(
+                        atom1_id=bond.get_atom1().get_id(),
+                        atom2_id=bond.get_atom2().get_id(),
+                        order=bond.get_order(),
+                    ) for bond in complex.get_bonds()
                 ),
             )
 

--- a/src/stk/molecular/topology_graphs/macrocycle/macrocycle.py
+++ b/src/stk/molecular/topology_graphs/macrocycle/macrocycle.py
@@ -42,6 +42,41 @@ class Macrocycle(TopologyGraph):
             ),
         )
 
+    .. moldoc::
+
+        import moldoc.molecule as molecule
+        import stk
+
+        macrocycle = stk.ConstructedMolecule(
+            topology_graph=stk.macrocycle.Macrocycle(
+                building_blocks=(
+                    stk.BuildingBlock('BrCCBr', [stk.BromoFactory()]),
+                    stk.BuildingBlock('BrCNCBr', [stk.BromoFactory()]),
+                ),
+                repeating_unit='AB',
+                num_repeating_units=5,
+            ),
+        )
+
+        moldoc_display_molecule = molecule.Molecule(
+            atoms=(
+                molecule.Atom(
+                    atomic_number=atom.get_atomic_number(),
+                    position=position,
+                ) for atom, position in zip(
+                    macrocycle.get_atoms(),
+                    macrocycle.get_position_matrix(),
+                )
+            ),
+            bonds=(
+                molecule.Bond(
+                    atom1_id=bond.get_atom1().get_id(),
+                    atom2_id=bond.get_atom2().get_id(),
+                    order=bond.get_order(),
+                ) for bond in macrocycle.get_bonds()
+            ),
+        )
+
     *Suggested Optimization*
 
     For :class:`.Macrocycle` topologies, it is recommended to use the
@@ -63,6 +98,42 @@ class Macrocycle(TopologyGraph):
             ),
         )
 
+    .. moldoc::
+
+        import moldoc.molecule as molecule
+        import stk
+
+        macrocycle = stk.ConstructedMolecule(
+            topology_graph=stk.macrocycle.Macrocycle(
+                building_blocks=(
+                    stk.BuildingBlock('BrCCBr', [stk.BromoFactory()]),
+                    stk.BuildingBlock('BrCNCBr', [stk.BromoFactory()]),
+                ),
+                repeating_unit='AB',
+                num_repeating_units=5,
+                optimizer=stk.MCHammer(),
+            ),
+        )
+
+        moldoc_display_molecule = molecule.Molecule(
+            atoms=(
+                molecule.Atom(
+                    atomic_number=atom.get_atomic_number(),
+                    position=position,
+                ) for atom, position in zip(
+                    macrocycle.get_atoms(),
+                    macrocycle.get_position_matrix(),
+                )
+            ),
+            bonds=(
+                molecule.Bond(
+                    atom1_id=bond.get_atom1().get_id(),
+                    atom2_id=bond.get_atom2().get_id(),
+                    order=bond.get_order(),
+                ) for bond in macrocycle.get_bonds()
+            ),
+        )
+
     *Defining the Orientation of Each Building Block*
 
     The `orientations` parameter allows the direction of each building
@@ -81,6 +152,43 @@ class Macrocycle(TopologyGraph):
                 repeating_unit='AB',
                 num_repeating_units=5,
                 orientations=(1, 0.5),
+            ),
+        )
+
+    .. moldoc::
+
+        import moldoc.molecule as molecule
+        import stk
+
+        bb1 = stk.BuildingBlock('BrCCBr', [stk.BromoFactory()])
+        bb2 = stk.BuildingBlock('BrCOCCBr', [stk.BromoFactory()])
+
+        macrocycle = stk.ConstructedMolecule(
+            topology_graph=stk.macrocycle.Macrocycle(
+                building_blocks=(bb1, bb2),
+                repeating_unit='AB',
+                num_repeating_units=5,
+                orientations=(1, 0.5),
+                random_seed=1,
+            ),
+        )
+
+        moldoc_display_molecule = molecule.Molecule(
+            atoms=(
+                molecule.Atom(
+                    atomic_number=atom.get_atomic_number(),
+                    position=position,
+                ) for atom, position in zip(
+                    macrocycle.get_atoms(),
+                    macrocycle.get_position_matrix(),
+                )
+            ),
+            bonds=(
+                molecule.Bond(
+                    atom1_id=bond.get_atom1().get_id(),
+                    atom2_id=bond.get_atom2().get_id(),
+                    order=bond.get_order(),
+                ) for bond in macrocycle.get_bonds()
             ),
         )
 

--- a/src/stk/molecular/topology_graphs/metal_complex/metal_complex.py
+++ b/src/stk/molecular/topology_graphs/metal_complex/metal_complex.py
@@ -101,8 +101,49 @@ class MetalComplex(TopologyGraph):
                     bonders=(1, ),
                     deleters=(),
                 ),
-            ]
+            ],
         )
+
+    .. moldoc::
+
+        import moldoc.molecule as molecule
+        import stk
+
+        bidentate = stk.BuildingBlock(
+            smiles='C=NC/C=N/Br',
+            functional_groups=[
+                stk.SmartsFunctionalGroupFactory(
+                    smarts='[#6]~[#7X2]~[#35]',
+                    bonders=(1, ),
+                    deleters=(),
+                ),
+                stk.SmartsFunctionalGroupFactory(
+                    smarts='[#6]~[#7X2]~[#6]',
+                    bonders=(1, ),
+                    deleters=(),
+                ),
+            ],
+        )
+
+        moldoc_display_molecule = molecule.Molecule(
+            atoms=(
+                molecule.Atom(
+                    atomic_number=atom.get_atomic_number(),
+                    position=position,
+                ) for atom, position in zip(
+                    bidentate.get_atoms(),
+                    bidentate.get_position_matrix(),
+                )
+            ),
+            bonds=(
+                molecule.Bond(
+                    atom1_id=bond.get_atom1().get_id(),
+                    atom2_id=bond.get_atom2().get_id(),
+                    order=bond.get_order(),
+                ) for bond in bidentate.get_bonds()
+            ),
+        )
+
 
     Finally, we can create the :class:`.MetalComplex`.
 
@@ -113,6 +154,66 @@ class MetalComplex(TopologyGraph):
                 metals=metal,
                 ligands=bidentate,
             )
+        )
+
+    .. moldoc::
+
+        import moldoc.molecule as molecule
+        import stk
+
+        metal = stk.BuildingBlock(
+            smiles='[Fe+2]',
+            functional_groups=(
+                stk.SingleAtom(stk.Fe(0, charge=2))
+                for i in range(6)
+            ),
+            position_matrix=[[0, 0, 0]],
+        )
+
+        bidentate = stk.BuildingBlock(
+            smiles='C=NC/C=N/Br',
+            functional_groups=[
+                stk.SmartsFunctionalGroupFactory(
+                    smarts='[#6]~[#7X2]~[#35]',
+                    bonders=(1, ),
+                    deleters=(),
+                ),
+                stk.SmartsFunctionalGroupFactory(
+                    smarts='[#6]~[#7X2]~[#6]',
+                    bonders=(1, ),
+                    deleters=(),
+                ),
+            ],
+        )
+
+        complex = stk.ConstructedMolecule(
+            topology_graph=stk.metal_complex.OctahedralLambda(
+                metals=metal,
+                ligands=bidentate,
+            )
+        )
+
+        moldoc_display_molecule = molecule.Molecule(
+            atoms=(
+                molecule.Atom(
+                    atomic_number=atom.get_atomic_number(),
+                    position=position,
+                ) for atom, position in zip(
+                    complex.get_atoms(),
+                    complex.get_position_matrix(),
+                )
+            ),
+            bonds=(
+                molecule.Bond(
+                    atom1_id=bond.get_atom1().get_id(),
+                    atom2_id=bond.get_atom2().get_id(),
+                    order=(
+                        bond.get_order()
+                        if bond.get_order() != 9
+                        else 1
+                    ),
+                ) for bond in complex.get_bonds()
+            ),
         )
 
     *Suggested Optimization*
@@ -154,7 +255,68 @@ class MetalComplex(TopologyGraph):
                 metals=metal,
                 ligands=bidentate,
                 optimizer=stk.MCHammer(),
-            )
+            ),
+        )
+
+    .. moldoc::
+
+        import moldoc.molecule as molecule
+        import stk
+
+        metal = stk.BuildingBlock(
+            smiles='[Fe+2]',
+            functional_groups=(
+                stk.SingleAtom(stk.Fe(0, charge=2))
+                for i in range(6)
+            ),
+            position_matrix=[[0, 0, 0]],
+        )
+
+        bidentate = stk.BuildingBlock(
+            smiles='C=NC/C=N/Br',
+            functional_groups=[
+                stk.SmartsFunctionalGroupFactory(
+                    smarts='[#6]~[#7X2]~[#35]',
+                    bonders=(1, ),
+                    deleters=(),
+                ),
+                stk.SmartsFunctionalGroupFactory(
+                    smarts='[#6]~[#7X2]~[#6]',
+                    bonders=(1, ),
+                    deleters=(),
+                ),
+            ]
+        )
+
+        complex = stk.ConstructedMolecule(
+            topology_graph=stk.metal_complex.OctahedralLambda(
+                metals=metal,
+                ligands=bidentate,
+                optimizer=stk.MCHammer(),
+            ),
+        )
+
+        moldoc_display_molecule = molecule.Molecule(
+            atoms=(
+                molecule.Atom(
+                    atomic_number=atom.get_atomic_number(),
+                    position=position,
+                ) for atom, position in zip(
+                    complex.get_atoms(),
+                    complex.get_position_matrix(),
+                )
+            ),
+            bonds=(
+                molecule.Bond(
+                    atom1_id=bond.get_atom1().get_id(),
+                    atom2_id=bond.get_atom2().get_id(),
+                    order=(
+                        bond.get_order()
+                        if bond.get_order() != 9
+                        else 1
+                    ),
+                ) for bond in complex.get_bonds()
+            ),
         )
 
     *Construction with Multiple Metals & Ligands*
@@ -190,7 +352,7 @@ class MetalComplex(TopologyGraph):
                     bonders=(1, ),
                     deleters=(),
                 ),
-            ]
+            ],
         )
 
         # Define a second organic linker with two functional groups.
@@ -207,18 +369,18 @@ class MetalComplex(TopologyGraph):
                     bonders=(1, ),
                     deleters=(),
                 ),
-            ]
+            ],
         )
 
         # Build heteroleptic complex.
         complex = stk.ConstructedMolecule(
-            stk.metal_complex.OctahedralLambda(
+            topology_graph=stk.metal_complex.OctahedralLambda(
                 metals=metal,
                 ligands={
                     bidentate1: (0, 1),
                     bidentate2: (2, ),
                 },
-            )
+            ),
         )
 
     However, if each ligand is has a different number of
@@ -229,12 +391,13 @@ class MetalComplex(TopologyGraph):
     metal complex you are using. These are detailed in the docstring
     for that specific metal vertex topology graph.
 
-    *Leaving Unsubstituted Sites*
+    *Unsubstituted Metal Complexes*
 
     Some metal complex topologies represent metal complexes with
     unsubstituted metal sites. For example,
-    here we show how to build a square planar
-    palladium(II) complex with two open metal sites.
+    :class:`.BidentateSquarePlanar` has all sites substituted and
+    :class:`.CisProtectedSquarePlanar` is the equivalent metal complex
+    with some unsubstituted sites
 
     .. testcode:: leaving-unsubstituted-sites
 
@@ -258,15 +421,72 @@ class MetalComplex(TopologyGraph):
                     bonders=(0, ),
                     deleters=(),
                 ),
-            ]
+            ],
         )
 
         # Construct a cis-protected square planar metal complex.
         complex = stk.ConstructedMolecule(
-            stk.metal_complex.CisProtectedSquarePlanar(
+            topology_graph=stk.metal_complex.CisProtectedSquarePlanar(
                 metals=pd,
                 ligands=bidentate_ligand,
-            )
+            ),
+        )
+
+    .. moldoc::
+
+        import moldoc.molecule as molecule
+        import stk
+
+        pd = stk.BuildingBlock(
+            smiles='[Pd+2]',
+            functional_groups=(
+                stk.SingleAtom(stk.Pd(0, charge=2))
+                for i in range(4)
+            ),
+            position_matrix=[[0, 0, 0]],
+        )
+
+        # Define a bidentate ligand with two functional groups.
+        bidentate_ligand = stk.BuildingBlock(
+            smiles='NCCN',
+            functional_groups=[
+                stk.SmartsFunctionalGroupFactory(
+                    smarts='[#7]~[#6]',
+                    bonders=(0, ),
+                    deleters=(),
+                ),
+            ],
+        )
+
+        # Construct a cis-protected square planar metal complex.
+        complex = stk.ConstructedMolecule(
+            topology_graph=stk.metal_complex.CisProtectedSquarePlanar(
+                metals=pd,
+                ligands=bidentate_ligand,
+            ),
+        )
+
+        moldoc_display_molecule = molecule.Molecule(
+            atoms=(
+                molecule.Atom(
+                    atomic_number=atom.get_atomic_number(),
+                    position=position,
+                ) for atom, position in zip(
+                    complex.get_atoms(),
+                    complex.get_position_matrix(),
+                )
+            ),
+            bonds=(
+                molecule.Bond(
+                    atom1_id=bond.get_atom1().get_id(),
+                    atom2_id=bond.get_atom2().get_id(),
+                    order=(
+                        bond.get_order()
+                        if bond.get_order() != 9
+                        else 1
+                    ),
+                ) for bond in complex.get_bonds()
+            ),
         )
 
     """

--- a/src/stk/molecular/topology_graphs/metal_complex/octahedral/octahedral.py
+++ b/src/stk/molecular/topology_graphs/metal_complex/octahedral/octahedral.py
@@ -13,6 +13,62 @@ class Octahedral(MetalComplex):
     """
     Represents a metal complex topology graph.
 
+    .. moldoc::
+
+        import moldoc.molecule as molecule
+        import stk
+
+        bb1 = stk.BuildingBlock(
+            smiles='[Fe+2]',
+            functional_groups=(
+                stk.SingleAtom(stk.Fe(0, charge=2))
+                for i in range(6)
+            ),
+            position_matrix=[[0, 0, 0]],
+        )
+        bb2 = stk.BuildingBlock(
+            smiles=(
+                'C1=NC=CC(C2=CC=CC(C3=C'
+                'C=CC=C3)=C2)=C1'
+            ),
+            functional_groups=[
+                stk.SmartsFunctionalGroupFactory(
+                    smarts='[#6]~[#7X2]~[#6]',
+                    bonders=(1, ),
+                    deleters=(),
+                ),
+            ],
+        )
+        complex = stk.ConstructedMolecule(
+            topology_graph=stk.metal_complex.Octahedral(
+                metals=bb1,
+                ligands=bb2,
+            ),
+        )
+
+        moldoc_display_molecule = molecule.Molecule(
+            atoms=(
+                molecule.Atom(
+                    atomic_number=atom.get_atomic_number(),
+                    position=position,
+                ) for atom, position in zip(
+                    complex.get_atoms(),
+                    complex.get_position_matrix(),
+                )
+            ),
+            bonds=(
+                molecule.Bond(
+                    atom1_id=bond.get_atom1().get_id(),
+                    atom2_id=bond.get_atom2().get_id(),
+                    order=(
+                        1
+                        if bond.get_order() == 9
+                        else bond.get_order()
+                    ),
+                ) for bond in complex.get_bonds()
+            ),
+        )
+
     Metal building blocks with at least six functional groups are
     required for this topology.
 

--- a/src/stk/molecular/topology_graphs/metal_complex/octahedral/octahedral_delta.py
+++ b/src/stk/molecular/topology_graphs/metal_complex/octahedral/octahedral_delta.py
@@ -13,6 +13,62 @@ class OctahedralDelta(MetalComplex):
     """
     Represents a metal complex topology graph.
 
+    .. moldoc::
+
+        import moldoc.molecule as molecule
+        import stk
+
+        bb1 = stk.BuildingBlock(
+            smiles='[Fe+2]',
+            functional_groups=(
+                stk.SingleAtom(stk.Fe(0, charge=2))
+                for i in range(6)
+            ),
+            position_matrix=[[0, 0, 0]],
+        )
+        bb2 = stk.BuildingBlock(
+            smiles=(
+                'C1=CC=NC(C2=CC=CC(C3=C'
+                'C=CC=N3)=C2)=C1'
+            ),
+            functional_groups=[
+                stk.SmartsFunctionalGroupFactory(
+                    smarts='[#6]~[#7X2]~[#6]',
+                    bonders=(1, ),
+                    deleters=(),
+                ),
+            ],
+        )
+        complex = stk.ConstructedMolecule(
+            topology_graph=stk.metal_complex.OctahedralDelta(
+                metals=bb1,
+                ligands=bb2,
+            ),
+        )
+
+        moldoc_display_molecule = molecule.Molecule(
+            atoms=(
+                molecule.Atom(
+                    atomic_number=atom.get_atomic_number(),
+                    position=position,
+                ) for atom, position in zip(
+                    complex.get_atoms(),
+                    complex.get_position_matrix(),
+                )
+            ),
+            bonds=(
+                molecule.Bond(
+                    atom1_id=bond.get_atom1().get_id(),
+                    atom2_id=bond.get_atom2().get_id(),
+                    order=(
+                        1
+                        if bond.get_order() == 9
+                        else bond.get_order()
+                    ),
+                ) for bond in complex.get_bonds()
+            ),
+        )
+
     Metal building blocks with at least six functional groups are
     required for this topology.
 

--- a/src/stk/molecular/topology_graphs/metal_complex/octahedral/octahedral_lambda.py
+++ b/src/stk/molecular/topology_graphs/metal_complex/octahedral/octahedral_lambda.py
@@ -13,6 +13,62 @@ class OctahedralLambda(MetalComplex):
     """
     Represents a metal complex topology graph.
 
+    .. moldoc::
+
+        import moldoc.molecule as molecule
+        import stk
+
+        bb1 = stk.BuildingBlock(
+            smiles='[Fe+2]',
+            functional_groups=(
+                stk.SingleAtom(stk.Fe(0, charge=2))
+                for i in range(6)
+            ),
+            position_matrix=[[0, 0, 0]],
+        )
+        bb2 = stk.BuildingBlock(
+            smiles=(
+                'C1=CC=NC(C2=CC=CC(C3=C'
+                'C=CC=N3)=C2)=C1'
+            ),
+            functional_groups=[
+                stk.SmartsFunctionalGroupFactory(
+                    smarts='[#6]~[#7X2]~[#6]',
+                    bonders=(1, ),
+                    deleters=(),
+                ),
+            ],
+        )
+        complex = stk.ConstructedMolecule(
+            topology_graph=stk.metal_complex.OctahedralLambda(
+                metals=bb1,
+                ligands=bb2,
+            ),
+        )
+
+        moldoc_display_molecule = molecule.Molecule(
+            atoms=(
+                molecule.Atom(
+                    atomic_number=atom.get_atomic_number(),
+                    position=position,
+                ) for atom, position in zip(
+                    complex.get_atoms(),
+                    complex.get_position_matrix(),
+                )
+            ),
+            bonds=(
+                molecule.Bond(
+                    atom1_id=bond.get_atom1().get_id(),
+                    atom2_id=bond.get_atom2().get_id(),
+                    order=(
+                        1
+                        if bond.get_order() == 9
+                        else bond.get_order()
+                    ),
+                ) for bond in complex.get_bonds()
+            ),
+        )
+
     Metal building blocks with at least six functional groups are
     required for this topology.
 

--- a/src/stk/molecular/topology_graphs/metal_complex/paddlewheel/paddlewheel.py
+++ b/src/stk/molecular/topology_graphs/metal_complex/paddlewheel/paddlewheel.py
@@ -13,6 +13,62 @@ class Paddlewheel(MetalComplex):
     """
     Represents a metal complex topology graph.
 
+    .. moldoc::
+
+        import moldoc.molecule as molecule
+        import stk
+
+        bb1 = stk.BuildingBlock(
+            smiles='[Pd+2]',
+            functional_groups=(
+                stk.SingleAtom(stk.Pd(0, charge=2))
+                for i in range(4)
+            ),
+            position_matrix=[[0, 0, 0]],
+        )
+        bb2 = stk.BuildingBlock(
+            smiles=(
+                'C1=CC=NC(C2=CC=CC(C3=C'
+                'C=CC=N3)=C2)=C1'
+            ),
+            functional_groups=[
+                stk.SmartsFunctionalGroupFactory(
+                    smarts='[#6]~[#7X2]~[#6]',
+                    bonders=(1, ),
+                    deleters=(),
+                ),
+            ],
+        )
+        complex = stk.ConstructedMolecule(
+            topology_graph=stk.metal_complex.Paddlewheel(
+                metals=bb1,
+                ligands=bb2,
+            ),
+        )
+
+        moldoc_display_molecule = molecule.Molecule(
+            atoms=(
+                molecule.Atom(
+                    atomic_number=atom.get_atomic_number(),
+                    position=position,
+                ) for atom, position in zip(
+                    complex.get_atoms(),
+                    complex.get_position_matrix(),
+                )
+            ),
+            bonds=(
+                molecule.Bond(
+                    atom1_id=bond.get_atom1().get_id(),
+                    atom2_id=bond.get_atom2().get_id(),
+                    order=(
+                        1
+                        if bond.get_order() == 9
+                        else bond.get_order()
+                    ),
+                ) for bond in complex.get_bonds()
+            ),
+        )
+
     Metal building blocks with at least four functional groups are
     required for this topology.
 

--- a/src/stk/molecular/topology_graphs/metal_complex/porphyrin/porphyrin.py
+++ b/src/stk/molecular/topology_graphs/metal_complex/porphyrin/porphyrin.py
@@ -13,6 +13,62 @@ class Porphyrin(MetalComplex):
     """
     Represents a metal complex topology graph.
 
+    .. moldoc::
+
+        import moldoc.molecule as molecule
+        import stk
+
+        bb1 = stk.BuildingBlock(
+            smiles='[Fe+2]',
+            functional_groups=(
+                stk.SingleAtom(stk.Fe(0, charge=2))
+                for i in range(6)
+            ),
+            position_matrix=[[0, 0, 0]],
+        )
+        bb2 = stk.BuildingBlock(
+            smiles=(
+                'C1=CC2=CC3=CC=C([N]3)C=C4C=CC'
+                '(=N4)C=C5C=CC(=N5)C=C1[N]2'
+            ),
+            functional_groups=[
+                stk.SmartsFunctionalGroupFactory(
+                    smarts='[#6]~[#7]~[#6]',
+                    bonders=(1, ),
+                    deleters=(),
+                ),
+            ],
+        )
+        complex = stk.ConstructedMolecule(
+            topology_graph=stk.metal_complex.Porphyrin(
+                metals=bb1,
+                ligands=bb2,
+            ),
+        )
+
+        moldoc_display_molecule = molecule.Molecule(
+            atoms=(
+                molecule.Atom(
+                    atomic_number=atom.get_atomic_number(),
+                    position=position,
+                ) for atom, position in zip(
+                    complex.get_atoms(),
+                    complex.get_position_matrix(),
+                )
+            ),
+            bonds=(
+                molecule.Bond(
+                    atom1_id=bond.get_atom1().get_id(),
+                    atom2_id=bond.get_atom2().get_id(),
+                    order=(
+                        1
+                        if bond.get_order() == 9
+                        else bond.get_order()
+                    ),
+                ) for bond in complex.get_bonds()
+            ),
+        )
+
     Metal building blocks with at least four functional groups are
     required for this topology.
 

--- a/src/stk/molecular/topology_graphs/metal_complex/square_planar/bidentate_square_planar.py
+++ b/src/stk/molecular/topology_graphs/metal_complex/square_planar/bidentate_square_planar.py
@@ -13,6 +13,62 @@ class BidentateSquarePlanar(MetalComplex):
     """
     Represents a square planar metal complex topology graph.
 
+    .. moldoc::
+
+        import moldoc.molecule as molecule
+        import stk
+
+        bb1 = stk.BuildingBlock(
+            smiles='[Pd+2]',
+            functional_groups=(
+                stk.SingleAtom(stk.Pd(0, charge=2))
+                for i in range(4)
+            ),
+            position_matrix=[[0, 0, 0]],
+        )
+        bb2 = stk.BuildingBlock(
+            smiles=(
+                'C1=CC=NC(C2=CC=CC(C3=C'
+                'C=CC=N3)=C2)=C1'
+            ),
+            functional_groups=[
+                stk.SmartsFunctionalGroupFactory(
+                    smarts='[#6]~[#7X2]~[#6]',
+                    bonders=(1, ),
+                    deleters=(),
+                ),
+            ],
+        )
+        complex = stk.ConstructedMolecule(
+            topology_graph=stk.metal_complex.BidentateSquarePlanar(
+                metals=bb1,
+                ligands=bb2,
+            ),
+        )
+
+        moldoc_display_molecule = molecule.Molecule(
+            atoms=(
+                molecule.Atom(
+                    atomic_number=atom.get_atomic_number(),
+                    position=position,
+                ) for atom, position in zip(
+                    complex.get_atoms(),
+                    complex.get_position_matrix(),
+                )
+            ),
+            bonds=(
+                molecule.Bond(
+                    atom1_id=bond.get_atom1().get_id(),
+                    atom2_id=bond.get_atom2().get_id(),
+                    order=(
+                        1
+                        if bond.get_order() == 9
+                        else bond.get_order()
+                    ),
+                ) for bond in complex.get_bonds()
+            ),
+        )
+
     Metal building blocks with at least four functional groups are
     required for this topology graph.
 

--- a/src/stk/molecular/topology_graphs/metal_complex/square_planar/cis_protected_square_planar.py
+++ b/src/stk/molecular/topology_graphs/metal_complex/square_planar/cis_protected_square_planar.py
@@ -13,6 +13,62 @@ class CisProtectedSquarePlanar(MetalComplex):
     """
     Represents a square planar metal complex topology graph.
 
+    .. moldoc::
+
+        import moldoc.molecule as molecule
+        import stk
+
+        bb1 = stk.BuildingBlock(
+            smiles='[Pd+2]',
+            functional_groups=(
+                stk.SingleAtom(stk.Pd(0, charge=2))
+                for i in range(4)
+            ),
+            position_matrix=[[0, 0, 0]],
+        )
+        bb2 = stk.BuildingBlock(
+            smiles=(
+                'C1=CC=NC(C2=CC=CC(C3=C'
+                'C=CC=N3)=C2)=C1'
+            ),
+            functional_groups=[
+                stk.SmartsFunctionalGroupFactory(
+                    smarts='[#6]~[#7X2]~[#6]',
+                    bonders=(1, ),
+                    deleters=(),
+                ),
+            ],
+        )
+        complex = stk.ConstructedMolecule(
+            topology_graph=stk.metal_complex.CisProtectedSquarePlanar(
+                metals=bb1,
+                ligands=bb2,
+            ),
+        )
+
+        moldoc_display_molecule = molecule.Molecule(
+            atoms=(
+                molecule.Atom(
+                    atomic_number=atom.get_atomic_number(),
+                    position=position,
+                ) for atom, position in zip(
+                    complex.get_atoms(),
+                    complex.get_position_matrix(),
+                )
+            ),
+            bonds=(
+                molecule.Bond(
+                    atom1_id=bond.get_atom1().get_id(),
+                    atom2_id=bond.get_atom2().get_id(),
+                    order=(
+                        1
+                        if bond.get_order() == 9
+                        else bond.get_order()
+                    ),
+                ) for bond in complex.get_bonds()
+            ),
+        )
+
     Metal building blocks with at least two functional groups are
     required for this topology graph.
 

--- a/src/stk/molecular/topology_graphs/metal_complex/square_planar/square_planar.py
+++ b/src/stk/molecular/topology_graphs/metal_complex/square_planar/square_planar.py
@@ -13,6 +13,62 @@ class SquarePlanar(MetalComplex):
     """
     Represents a square planar metal complex topology graph.
 
+    .. moldoc::
+
+        import moldoc.molecule as molecule
+        import stk
+
+        bb1 = stk.BuildingBlock(
+            smiles='[Pd+2]',
+            functional_groups=(
+                stk.SingleAtom(stk.Pd(0, charge=2))
+                for i in range(4)
+            ),
+            position_matrix=[[0, 0, 0]],
+        )
+        bb2 = stk.BuildingBlock(
+            smiles=(
+                'C1=NC=CC(C2=CC=CC(C3=C'
+                'C=CC=C3)=C2)=C1'
+            ),
+            functional_groups=[
+                stk.SmartsFunctionalGroupFactory(
+                    smarts='[#6]~[#7X2]~[#6]',
+                    bonders=(1, ),
+                    deleters=(),
+                ),
+            ],
+        )
+        complex = stk.ConstructedMolecule(
+            topology_graph=stk.metal_complex.SquarePlanar(
+                metals=bb1,
+                ligands=bb2,
+            ),
+        )
+
+        moldoc_display_molecule = molecule.Molecule(
+            atoms=(
+                molecule.Atom(
+                    atomic_number=atom.get_atomic_number(),
+                    position=position,
+                ) for atom, position in zip(
+                    complex.get_atoms(),
+                    complex.get_position_matrix(),
+                )
+            ),
+            bonds=(
+                molecule.Bond(
+                    atom1_id=bond.get_atom1().get_id(),
+                    atom2_id=bond.get_atom2().get_id(),
+                    order=(
+                        1
+                        if bond.get_order() == 9
+                        else bond.get_order()
+                    ),
+                ) for bond in complex.get_bonds()
+            ),
+        )
+
     Metal building blocks with at least four functional groups are
     required for this topology graph.
 

--- a/src/stk/molecular/topology_graphs/polymer/linear/linear.py
+++ b/src/stk/molecular/topology_graphs/polymer/linear/linear.py
@@ -52,9 +52,44 @@ class Linear(TopologyGraph):
             topology_graph=stk.polymer.Linear(
                 building_blocks=(bb1, bb2),
                 repeating_unit='AB',
-                num_repeating_units=12,
+                num_repeating_units=4,
             ),
         )
+
+    .. moldoc::
+
+        import moldoc.molecule as molecule
+        import stk
+
+        bb1 = stk.BuildingBlock('NCCN', [stk.PrimaryAminoFactory()])
+        bb2 = stk.BuildingBlock('O=CCC=O', [stk.AldehydeFactory()])
+        polymer = stk.ConstructedMolecule(
+            topology_graph=stk.polymer.Linear(
+                building_blocks=(bb1, bb2),
+                repeating_unit='AB',
+                num_repeating_units=4,
+            ),
+        )
+
+        moldoc_display_molecule = molecule.Molecule(
+            atoms=(
+                molecule.Atom(
+                    atomic_number=atom.get_atomic_number(),
+                    position=position,
+                ) for atom, position in zip(
+                    polymer.get_atoms(),
+                    polymer.get_position_matrix(),
+                )
+            ),
+            bonds=(
+                molecule.Bond(
+                    atom1_id=bond.get_atom1().get_id(),
+                    atom2_id=bond.get_atom2().get_id(),
+                    order=bond.get_order(),
+                ) for bond in polymer.get_bonds()
+            ),
+        )
+
 
     *Suggested Optimization*
 
@@ -72,10 +107,48 @@ class Linear(TopologyGraph):
             topology_graph=stk.polymer.Linear(
                 building_blocks=(bb1, bb2),
                 repeating_unit='AB',
-                num_repeating_units=12,
+                num_repeating_units=4,
                 # Setting scale_steps to False tends to lead to a
                 # better structure.
                 optimizer=stk.Collapser(scale_steps=False),
+            ),
+        )
+
+    .. moldoc::
+
+        import moldoc.molecule as molecule
+        import stk
+
+        bb1 = stk.BuildingBlock('NCCN', [stk.PrimaryAminoFactory()])
+        bb2 = stk.BuildingBlock('O=CCC=O', [stk.AldehydeFactory()])
+
+        polymer = stk.ConstructedMolecule(
+            topology_graph=stk.polymer.Linear(
+                building_blocks=(bb1, bb2),
+                repeating_unit='AB',
+                num_repeating_units=4,
+                # Setting scale_steps to False tends to lead to a
+                # better structure.
+                optimizer=stk.Collapser(scale_steps=False),
+            ),
+        )
+
+        moldoc_display_molecule = molecule.Molecule(
+            atoms=(
+                molecule.Atom(
+                    atomic_number=atom.get_atomic_number(),
+                    position=position,
+                ) for atom, position in zip(
+                    polymer.get_atoms(),
+                    polymer.get_position_matrix(),
+                )
+            ),
+            bonds=(
+                molecule.Bond(
+                    atom1_id=bond.get_atom1().get_id(),
+                    atom2_id=bond.get_atom2().get_id(),
+                    order=bond.get_order(),
+                ) for bond in polymer.get_bonds()
             ),
         )
 
@@ -88,15 +161,51 @@ class Linear(TopologyGraph):
 
         import stk
 
-        bb1 = stk.BuildingBlock('NCCN', [stk.PrimaryAminoFactory()])
+        bb1 = stk.BuildingBlock('NCC(F)N', [stk.PrimaryAminoFactory()])
         bb2 = stk.BuildingBlock('O=CCC=O', [stk.AldehydeFactory()])
-        bb3 = stk.BuildingBlock('CCN', [stk.PrimaryAminoFactory()])
+        bb3 = stk.BuildingBlock('BrCCN', [stk.PrimaryAminoFactory()])
 
         polymer = stk.ConstructedMolecule(
             topology_graph=stk.polymer.Linear(
                 building_blocks=(bb1, bb2, bb3),
                 repeating_unit='ABABC',
                 num_repeating_units=1,
+            ),
+        )
+
+    .. moldoc::
+
+        import moldoc.molecule as molecule
+        import stk
+
+        bb1 = stk.BuildingBlock('NCC(F)N', [stk.PrimaryAminoFactory()])
+        bb2 = stk.BuildingBlock('O=CCC=O', [stk.AldehydeFactory()])
+        bb3 = stk.BuildingBlock('BrCCN', [stk.PrimaryAminoFactory()])
+
+        polymer = stk.ConstructedMolecule(
+            topology_graph=stk.polymer.Linear(
+                building_blocks=(bb1, bb2, bb3),
+                repeating_unit='ABABC',
+                num_repeating_units=1,
+            ),
+        )
+
+        moldoc_display_molecule = molecule.Molecule(
+            atoms=(
+                molecule.Atom(
+                    atomic_number=atom.get_atomic_number(),
+                    position=position,
+                ) for atom, position in zip(
+                    polymer.get_atoms(),
+                    polymer.get_position_matrix(),
+                )
+            ),
+            bonds=(
+                molecule.Bond(
+                    atom1_id=bond.get_atom1().get_id(),
+                    atom2_id=bond.get_atom2().get_id(),
+                    order=bond.get_order(),
+                ) for bond in polymer.get_bonds()
             ),
         )
 
@@ -110,7 +219,10 @@ class Linear(TopologyGraph):
         import stk
 
         bb1 = stk.BuildingBlock('O=CCC=O', [stk.AldehydeFactory()])
-        bb2 = stk.BuildingBlock('NCNCCN', [stk.PrimaryAminoFactory()])
+        bb2 = stk.BuildingBlock(
+            smiles='NC(Br)CN',
+            functional_groups=[stk.PrimaryAminoFactory()],
+        )
 
         p1 = stk.ConstructedMolecule(
             topology_graph=stk.polymer.Linear(
@@ -118,6 +230,45 @@ class Linear(TopologyGraph):
                 repeating_unit='AB',
                 num_repeating_units=5,
                 orientations=(1, 0.5),
+            ),
+        )
+
+    .. moldoc::
+
+        import moldoc.molecule as molecule
+        import stk
+
+        bb1 = stk.BuildingBlock('O=CC(F)CC=O', [stk.AldehydeFactory()])
+        bb2 = stk.BuildingBlock(
+            smiles='NC(Br)CN',
+            functional_groups=[stk.PrimaryAminoFactory()],
+        )
+
+        polymer = stk.ConstructedMolecule(
+            topology_graph=stk.polymer.Linear(
+                building_blocks=(bb1, bb2),
+                repeating_unit='AB',
+                num_repeating_units=5,
+                orientations=(1, 0.5),
+            ),
+        )
+
+        moldoc_display_molecule = molecule.Molecule(
+            atoms=(
+                molecule.Atom(
+                    atomic_number=atom.get_atomic_number(),
+                    position=position,
+                ) for atom, position in zip(
+                    polymer.get_atoms(),
+                    polymer.get_position_matrix(),
+                )
+            ),
+            bonds=(
+                molecule.Bond(
+                    atom1_id=bond.get_atom1().get_id(),
+                    atom2_id=bond.get_atom2().get_id(),
+                    order=bond.get_order(),
+                ) for bond in polymer.get_bonds()
             ),
         )
 

--- a/src/stk/molecular/topology_graphs/polymer/linear/linear.py
+++ b/src/stk/molecular/topology_graphs/polymer/linear/linear.py
@@ -250,7 +250,7 @@ class Linear(TopologyGraph):
                 repeating_unit='AB',
                 num_repeating_units=5,
                 orientations=(1, 0.5),
-                random_seed=4,
+                random_seed=1,
             ),
         )
 

--- a/src/stk/molecular/topology_graphs/polymer/linear/linear.py
+++ b/src/stk/molecular/topology_graphs/polymer/linear/linear.py
@@ -250,6 +250,7 @@ class Linear(TopologyGraph):
                 repeating_unit='AB',
                 num_repeating_units=5,
                 orientations=(1, 0.5),
+                random_seed=4,
             ),
         )
 

--- a/src/stk/molecular/topology_graphs/rotaxane/nrotaxane.py
+++ b/src/stk/molecular/topology_graphs/rotaxane/nrotaxane.py
@@ -63,6 +63,63 @@ class NRotaxane(TopologyGraph):
             ),
         )
 
+    .. moldoc::
+
+        import moldoc.molecule as molecule
+        import stk
+
+        cycle = stk.ConstructedMolecule(
+            topology_graph=stk.macrocycle.Macrocycle(
+                building_blocks=(
+                    stk.BuildingBlock(
+                        smiles='[Br]CC[Br]',
+                        functional_groups=[stk.BromoFactory()],
+                    ),
+                ),
+                repeating_unit='A',
+                num_repeating_units=5,
+            ),
+        )
+        axle = stk.ConstructedMolecule(
+            topology_graph=stk.polymer.Linear(
+                building_blocks=(
+                    stk.BuildingBlock('BrCCBr', [stk.BromoFactory()]),
+                    stk.BuildingBlock('BrCNCBr', [stk.BromoFactory()]),
+                ),
+                repeating_unit='AB',
+                num_repeating_units=7,
+            )
+        )
+        rotaxane = stk.ConstructedMolecule(
+            topology_graph=stk.rotaxane.NRotaxane(
+                axle=stk.BuildingBlock.init_from_molecule(axle),
+                cycles=(
+                    stk.BuildingBlock.init_from_molecule(cycle),
+                ),
+                repeating_unit='A',
+                num_repeating_units=3,
+            ),
+        )
+
+        moldoc_display_molecule = molecule.Molecule(
+            atoms=(
+                molecule.Atom(
+                    atomic_number=atom.get_atomic_number(),
+                    position=position,
+                ) for atom, position in zip(
+                    rotaxane.get_atoms(),
+                    rotaxane.get_position_matrix(),
+                )
+            ),
+            bonds=(
+                molecule.Bond(
+                    atom1_id=bond.get_atom1().get_id(),
+                    atom2_id=bond.get_atom2().get_id(),
+                    order=bond.get_order(),
+                ) for bond in rotaxane.get_bonds()
+            ),
+        )
+
     *Suggested Optimization*
 
     For :class:`.NRotaxane` topologies, there is no need to use an

--- a/tests/docker/environment.yml
+++ b/tests/docker/environment.yml
@@ -107,6 +107,7 @@ dependencies:
     - jinja2==3.0.1
     - markupsafe==2.0.1
     - mchammer==1.0.2
+    - moldoc==0.0.2
     - multiprocess==0.70.11.1
     - mypy==0.910
     - mypy-extensions==0.4.3


### PR DESCRIPTION
Related Issues: #207 

Documentation now has 3D models of molecules. This was done by adding `moldoc` as a dependency and using the `moldoc` directive to define molecules to show.