### PR TITLE
Use a flake8 config file

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,5 @@
+[flake8]
+max-line-length = 71
+count = True
+show-source = True
+statistics = True

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,12 +13,7 @@ jobs:
               uses: actions/checkout@v2
 
             - name: Lint with flake8
-              run: conda run -n stk
-                flake8 .
-                    --count
-                    --show-source
-                    --max-line-length=71
-                    --statistics
+              run: conda run -n stk flake8 .
 
     pytest-stable-linux:
         runs-on: ubuntu-20.04


### PR DESCRIPTION
Use a config file for flake8, instead of specifying options in the
workflow file. This ensures that flake8 uses the same options regardless
of if it is run manually or in CI.
