### PR TITLE
Unqualify imports

### DIFF
--- a/src/stk/molecular/__init__.py
+++ b/src/stk/molecular/__init__.py
@@ -1,7 +1,8 @@
 from .topology_graphs import *  # noqa
 from .functional_groups import *  # noqa
 from .molecule import *  # noqa
-from .molecules import *  # noqa
+from .building_block import *  # noqa
+from .constructed_molecule import *  # noqa
 from .atoms import *  # noqa
 from .bonds import *  # noqa
 from .reactions import *  # noqa

--- a/src/stk/molecular/atoms/atom.py
+++ b/src/stk/molecular/atoms/atom.py
@@ -6,6 +6,10 @@ Atom
 
 from __future__ import annotations
 
+__all__ = (
+    'Atom',
+)
+
 
 class Atom:
     """

--- a/src/stk/molecular/atoms/elements.py
+++ b/src/stk/molecular/atoms/elements.py
@@ -9,13 +9,13 @@ Defines an :class:`.Atom` class for each element.
 from __future__ import annotations
 
 import typing
-from . import atom as _atom
+from .atom import Atom
 
 
 _T = typing.TypeVar('_T', bound='AtomImpl')
 
 
-class AtomImpl(_atom.Atom):
+class AtomImpl(Atom):
     """
     An implementation of the :class:`.Atom` interface.
 

--- a/src/stk/molecular/bonds/bond.py
+++ b/src/stk/molecular/bonds/bond.py
@@ -8,8 +8,11 @@ from __future__ import annotations
 
 import typing
 
-from .. import atoms as _atoms
+from ..atoms import Atom
 
+__all__ = (
+    'Bond',
+)
 
 _T = typing.TypeVar('_T', bound='Bond')
 
@@ -45,8 +48,8 @@ class Bond:
 
     def __init__(
         self,
-        atom1: _atoms.Atom,
-        atom2: _atoms.Atom,
+        atom1: Atom,
+        atom2: Atom,
         order: int,
         periodicity: tuple[int, int, int] = (0, 0, 0),
     ) -> None:
@@ -80,7 +83,7 @@ class Bond:
         self._order = order
         self._periodicity = periodicity
 
-    def get_atom1(self) -> _atoms.Atom:
+    def get_atom1(self) -> Atom:
         """
         Get the first atom of the bond.
 
@@ -92,7 +95,7 @@ class Bond:
 
         return self._atom1
 
-    def get_atom2(self) -> _atoms.Atom:
+    def get_atom2(self) -> Atom:
         """
         Get the second atom of the bond.
 
@@ -153,7 +156,7 @@ class Bond:
         )
         return clone
 
-    def _with_atoms(self: _T, atom_map: dict[int, _atoms.Atom]) -> _T:
+    def _with_atoms(self: _T, atom_map: dict[int, Atom]) -> _T:
         """
         Modify the bond.
 
@@ -163,7 +166,7 @@ class Bond:
         self._atom2 = atom_map.get(self._atom2.get_id(), self._atom2)
         return self
 
-    def with_atoms(self, atom_map: dict[int, _atoms.Atom]) -> Bond:
+    def with_atoms(self, atom_map: dict[int, Atom]) -> Bond:
         """
         Return a clone holding different atoms.
 

--- a/src/stk/molecular/building_block.py
+++ b/src/stk/molecular/building_block.py
@@ -16,11 +16,11 @@ import pathlib
 from collections import abc
 
 from stk.utilities import typing as _typing
-from ..functional_groups import FunctionalGroup, FunctionalGroupFactory
-from ..atoms import Atom
-from ..bonds import Bond
-from ..molecule import Molecule
-from ... import utilities as _utilities
+from .functional_groups import FunctionalGroup, FunctionalGroupFactory
+from .atoms import Atom
+from .bonds import Bond
+from .molecule import Molecule
+from .. import utilities as _utilities
 
 
 __all__ = (

--- a/src/stk/molecular/constructed_molecule.py
+++ b/src/stk/molecular/constructed_molecule.py
@@ -13,11 +13,11 @@ import rdkit.Chem.AllChem as rdkit
 from collections import abc
 
 from stk.utilities.typing import OneOrMany
-from ..molecule import Molecule
-from ..atoms import Atom, AtomInfo
-from ..bonds import Bond, BondInfo
-from .. import molecular_utilities as _utilities
-from ..topology_graphs import TopologyGraph, ConstructionResult
+from .molecule import Molecule
+from .atoms import Atom, AtomInfo
+from .bonds import Bond, BondInfo
+from . import molecular_utilities as _utilities
+from .topology_graphs import TopologyGraph, ConstructionResult
 
 
 _T = typing.TypeVar('_T', bound='ConstructedMolecule')

--- a/src/stk/molecular/functional_groups/factories/alcohol_factory.py
+++ b/src/stk/molecular/functional_groups/factories/alcohol_factory.py
@@ -9,11 +9,11 @@ from __future__ import annotations
 import typing
 from collections import abc
 
-from . import functional_group_factory as _functional_group_factory
-from . import utilities as _utilities
-from .. import functional_groups as _functional_groups
-from ... import molecule as _molecule
-from ...atoms import elements as _elements
+from .functional_group_factory import FunctionalGroupFactory
+from .utilities import get_atom_ids
+from ..functional_groups import Alcohol
+from ...molecule import Molecule
+from ...atoms import O, H
 
 
 __all__ = (
@@ -24,7 +24,7 @@ __all__ = (
 _ValidIndex = typing.Literal[0, 1, 2]
 
 
-class AlcoholFactory(_functional_group_factory.FunctionalGroupFactory):
+class AlcoholFactory(FunctionalGroupFactory):
     """
     Creates :class:`.Alcohol` instances.
 
@@ -149,14 +149,14 @@ class AlcoholFactory(_functional_group_factory.FunctionalGroupFactory):
 
     def get_functional_groups(
         self,
-        molecule: _molecule.Molecule,
-    ) -> abc.Iterable[_functional_groups.Alcohol]:
+        molecule: Molecule,
+    ) -> abc.Iterable[Alcohol]:
 
-        for atom_ids in _utilities.get_atom_ids('[*][O][H]', molecule):
+        for atom_ids in get_atom_ids('[*][O][H]', molecule):
             atoms = tuple(molecule.get_atoms(atom_ids))
-            yield _functional_groups.Alcohol(
-                oxygen=typing.cast(_elements.O, atoms[1]),
-                hydrogen=typing.cast(_elements.H, atoms[2]),
+            yield Alcohol(
+                oxygen=typing.cast(O, atoms[1]),
+                hydrogen=typing.cast(H, atoms[2]),
                 atom=atoms[0],
                 bonders=tuple(atoms[i] for i in self._bonders),
                 deleters=tuple(atoms[i] for i in self._deleters),

--- a/src/stk/molecular/functional_groups/factories/aldehyde_factory.py
+++ b/src/stk/molecular/functional_groups/factories/aldehyde_factory.py
@@ -9,11 +9,11 @@ from __future__ import annotations
 import typing
 from collections import abc
 
-from . import functional_group_factory as _functional_group_factory
-from . import utilities as _utilities
-from .. import functional_groups as _functional_groups
-from ... import molecule as _molecule
-from ...atoms import elements as _elements
+from .functional_group_factory import FunctionalGroupFactory
+from .utilities import get_atom_ids
+from ..functional_groups import Aldehyde
+from ...molecule import Molecule
+from ...atoms import C, O, H
 
 
 __all__ = (
@@ -24,9 +24,7 @@ __all__ = (
 _ValidIndex = typing.Literal[0, 1, 2, 3]
 
 
-class AldehydeFactory(
-    _functional_group_factory.FunctionalGroupFactory,
-):
+class AldehydeFactory(FunctionalGroupFactory):
     """
     Creates :class:`.Aldehyde` instances.
 
@@ -148,18 +146,18 @@ class AldehydeFactory(
 
     def get_functional_groups(
         self,
-        molecule: _molecule.Molecule,
-    ) -> abc.Iterable[_functional_groups.Aldehyde]:
+        molecule: Molecule,
+    ) -> abc.Iterable[Aldehyde]:
 
-        for atom_ids in _utilities.get_atom_ids(
+        for atom_ids in get_atom_ids(
             query='[*][C](=[O])[H]',
             molecule=molecule,
         ):
             atoms = tuple(molecule.get_atoms(atom_ids))
-            yield _functional_groups.Aldehyde(
-                carbon=typing.cast(_elements.C, atoms[1]),
-                oxygen=typing.cast(_elements.O, atoms[2]),
-                hydrogen=typing.cast(_elements.H, atoms[3]),
+            yield Aldehyde(
+                carbon=typing.cast(C, atoms[1]),
+                oxygen=typing.cast(O, atoms[2]),
+                hydrogen=typing.cast(H, atoms[3]),
                 atom=atoms[0],
                 bonders=tuple(atoms[i] for i in self._bonders),
                 deleters=tuple(atoms[i] for i in self._deleters),

--- a/src/stk/molecular/functional_groups/factories/amide_factory.py
+++ b/src/stk/molecular/functional_groups/factories/amide_factory.py
@@ -9,11 +9,11 @@ from __future__ import annotations
 import typing
 from collections import abc
 
-from . import functional_group_factory as _functional_group_factory
-from . import utilities as _utilities
-from .. import functional_groups as _functional_groups
-from ... import molecule as _molecule
-from ...atoms import elements as _elements
+from .functional_group_factory import FunctionalGroupFactory
+from .utilities import get_atom_ids
+from ..functional_groups import Amide
+from ...molecule import Molecule
+from ...atoms import C, O, H, N
 
 
 __all__ = (
@@ -24,9 +24,7 @@ __all__ = (
 _ValidIndex = typing.Literal[0, 1, 2, 3, 4, 5]
 
 
-class AmideFactory(
-    _functional_group_factory.FunctionalGroupFactory,
-):
+class AmideFactory(FunctionalGroupFactory):
     """
     Creates :class:`.Amide` instances.
 
@@ -147,20 +145,20 @@ class AmideFactory(
 
     def get_functional_groups(
         self,
-        molecule: _molecule.Molecule,
-    ) -> abc.Iterable[_functional_groups.Amide]:
+        molecule: Molecule,
+    ) -> abc.Iterable[Amide]:
 
-        for atom_ids in _utilities.get_atom_ids(
+        for atom_ids in get_atom_ids(
             query='[*][C](=[O])[N]([H])[H]',
             molecule=molecule,
         ):
             atoms = tuple(molecule.get_atoms(atom_ids))
-            yield _functional_groups.Amide(
-                carbon=typing.cast(_elements.C, atoms[1]),
-                oxygen=typing.cast(_elements.O, atoms[2]),
-                nitrogen=typing.cast(_elements.N, atoms[3]),
-                hydrogen1=typing.cast(_elements.H, atoms[4]),
-                hydrogen2=typing.cast(_elements.H, atoms[5]),
+            yield Amide(
+                carbon=typing.cast(C, atoms[1]),
+                oxygen=typing.cast(O, atoms[2]),
+                nitrogen=typing.cast(N, atoms[3]),
+                hydrogen1=typing.cast(H, atoms[4]),
+                hydrogen2=typing.cast(H, atoms[5]),
                 atom=atoms[0],
                 bonders=tuple(atoms[i] for i in self._bonders),
                 deleters=tuple(atoms[i] for i in self._deleters),

--- a/src/stk/molecular/functional_groups/factories/boronic_acid_factory.py
+++ b/src/stk/molecular/functional_groups/factories/boronic_acid_factory.py
@@ -9,11 +9,11 @@ from __future__ import annotations
 import typing
 from collections import abc
 
-from . import functional_group_factory as _functional_group_factory
-from . import utilities as _utilities
-from .. import functional_groups as _functional_groups
-from ... import molecule as _molecule
-from ...atoms import elements as _elements
+from .functional_group_factory import FunctionalGroupFactory
+from .utilities import get_atom_ids
+from ..functional_groups import BoronicAcid
+from ...molecule import Molecule
+from ...atoms import O, H, B
 
 
 __all__ = (
@@ -24,9 +24,7 @@ __all__ = (
 _ValidIndex = typing.Literal[0, 1, 2, 3, 4, 5]
 
 
-class BoronicAcidFactory(
-    _functional_group_factory.FunctionalGroupFactory,
-):
+class BoronicAcidFactory(FunctionalGroupFactory):
     """
     Creates :class:`.BoronicAcid` instances.
 
@@ -149,20 +147,20 @@ class BoronicAcidFactory(
 
     def get_functional_groups(
         self,
-        molecule: _molecule.Molecule,
-    ) -> abc.Iterable[_functional_groups.BoronicAcid]:
+        molecule: Molecule,
+    ) -> abc.Iterable[BoronicAcid]:
 
-        for atom_ids in _utilities.get_atom_ids(
+        for atom_ids in get_atom_ids(
             query='[*][B]([O][H])[O][H]',
             molecule=molecule,
         ):
             atoms = tuple(molecule.get_atoms(atom_ids))
-            yield _functional_groups.BoronicAcid(
-                boron=typing.cast(_elements.B, atoms[1]),
-                oxygen1=typing.cast(_elements.O, atoms[2]),
-                hydrogen1=typing.cast(_elements.H, atoms[3]),
-                oxygen2=typing.cast(_elements.O, atoms[4]),
-                hydrogen2=typing.cast(_elements.H, atoms[5]),
+            yield BoronicAcid(
+                boron=typing.cast(B, atoms[1]),
+                oxygen1=typing.cast(O, atoms[2]),
+                hydrogen1=typing.cast(H, atoms[3]),
+                oxygen2=typing.cast(O, atoms[4]),
+                hydrogen2=typing.cast(H, atoms[5]),
                 atom=atoms[0],
                 bonders=tuple(atoms[i] for i in self._bonders),
                 deleters=tuple(atoms[i] for i in self._deleters),

--- a/src/stk/molecular/functional_groups/factories/bromo_factory.py
+++ b/src/stk/molecular/functional_groups/factories/bromo_factory.py
@@ -9,12 +9,11 @@ from __future__ import annotations
 import typing
 from collections import abc
 
-from . import functional_group_factory as _functional_group_factory
-from . import utilities as _utilities
-from .. import functional_groups as _functional_groups
-from ... import molecule as _molecule
-from ...atoms import elements as _elements
-
+from .functional_group_factory import FunctionalGroupFactory
+from .utilities import get_atom_ids
+from ..functional_groups import Bromo
+from ...molecule import Molecule
+from ...atoms import Br
 
 __all__ = (
     'BromoFactory',
@@ -24,9 +23,7 @@ __all__ = (
 _ValidIndex = typing.Literal[0, 1]
 
 
-class BromoFactory(
-    _functional_group_factory.FunctionalGroupFactory,
-):
+class BromoFactory(FunctionalGroupFactory):
     """
     Creates :class:`.Bromo` instances.
 
@@ -100,13 +97,13 @@ class BromoFactory(
 
     def get_functional_groups(
         self,
-        molecule: _molecule.Molecule,
-    ) -> abc.Iterable[_functional_groups.Bromo]:
+        molecule: Molecule,
+    ) -> abc.Iterable[Bromo]:
 
-        for atom_ids in _utilities.get_atom_ids('[*][Br]', molecule):
+        for atom_ids in get_atom_ids('[*][Br]', molecule):
             atoms = tuple(molecule.get_atoms(atom_ids))
-            yield _functional_groups.Bromo(
-                bromine=typing.cast(_elements.Br, atoms[1]),
+            yield Bromo(
+                bromine=typing.cast(Br, atoms[1]),
                 atom=atoms[0],
                 bonders=tuple(atoms[i] for i in self._bonders),
                 deleters=tuple(atoms[i] for i in self._deleters),

--- a/src/stk/molecular/functional_groups/factories/carboxylic_acid_factory.py
+++ b/src/stk/molecular/functional_groups/factories/carboxylic_acid_factory.py
@@ -9,11 +9,11 @@ from __future__ import annotations
 import typing
 from collections import abc
 
-from . import functional_group_factory as _functional_group_factory
-from . import utilities as _utilities
-from .. import functional_groups as _functional_groups
-from ... import molecule as _molecule
-from ...atoms import elements as _elements
+from .functional_group_factory import FunctionalGroupFactory
+from .utilities import get_atom_ids
+from ..functional_groups import CarboxylicAcid
+from ...molecule import Molecule
+from ...atoms import C, O, H
 
 
 __all__ = (
@@ -23,9 +23,7 @@ __all__ = (
 _ValidIndex = typing.Literal[0, 1, 2, 3, 4]
 
 
-class CarboxylicAcidFactory(
-    _functional_group_factory.FunctionalGroupFactory,
-):
+class CarboxylicAcidFactory(FunctionalGroupFactory):
     """
     Creates :class:`.CarboxylicAcid` instances.
 
@@ -148,19 +146,19 @@ class CarboxylicAcidFactory(
 
     def get_functional_groups(
         self,
-        molecule: _molecule.Molecule,
-    ) -> abc.Iterable[_functional_groups.CarboxylicAcid]:
+        molecule: Molecule,
+    ) -> abc.Iterable[CarboxylicAcid]:
 
-        for atom_ids in _utilities.get_atom_ids(
+        for atom_ids in get_atom_ids(
             query='[*][C](=[O])[O][H]',
             molecule=molecule,
         ):
             atoms = tuple(molecule.get_atoms(atom_ids))
-            yield _functional_groups.CarboxylicAcid(
-                carbon=typing.cast(_elements.C, atoms[1]),
-                oxygen1=typing.cast(_elements.O, atoms[2]),
-                oxygen2=typing.cast(_elements.O, atoms[3]),
-                hydrogen=typing.cast(_elements.H, atoms[4]),
+            yield CarboxylicAcid(
+                carbon=typing.cast(C, atoms[1]),
+                oxygen1=typing.cast(O, atoms[2]),
+                oxygen2=typing.cast(O, atoms[3]),
+                hydrogen=typing.cast(H, atoms[4]),
                 atom=atoms[0],
                 bonders=tuple(atoms[i] for i in self._bonders),
                 deleters=tuple(atoms[i] for i in self._deleters),

--- a/src/stk/molecular/functional_groups/factories/dibromo_factory.py
+++ b/src/stk/molecular/functional_groups/factories/dibromo_factory.py
@@ -9,11 +9,11 @@ from __future__ import annotations
 import typing
 from collections import abc
 
-from . import functional_group_factory as _functional_group_factory
-from . import utilities as _utilities
-from .. import functional_groups as _functional_groups
-from ... import molecule as _molecule
-from ...atoms import elements as _elements
+from .functional_group_factory import FunctionalGroupFactory
+from .utilities import get_atom_ids
+from ..functional_groups import Dibromo
+from ...molecule import Molecule
+from ...atoms import Br
 
 
 __all__ = (
@@ -23,9 +23,7 @@ __all__ = (
 _ValidIndex = typing.Literal[0, 1, 2, 3]
 
 
-class DibromoFactory(
-    _functional_group_factory.FunctionalGroupFactory,
-):
+class DibromoFactory(FunctionalGroupFactory):
     """
     Creates :class:`.Dibromo` instances.
 
@@ -144,19 +142,19 @@ class DibromoFactory(
 
     def get_functional_groups(
         self,
-        molecule: _molecule.Molecule,
-    ) -> abc.Iterable[_functional_groups.Dibromo]:
+        molecule: Molecule,
+    ) -> abc.Iterable[Dibromo]:
 
-        for atom_ids in _utilities.get_atom_ids(
+        for atom_ids in get_atom_ids(
             query='[Br][#6]~[#6][Br]',
             molecule=molecule,
         ):
             atoms = tuple(molecule.get_atoms(atom_ids))
-            yield _functional_groups.Dibromo(
+            yield Dibromo(
                 atom1=atoms[1],
-                bromine1=typing.cast(_elements.Br, atoms[0]),
+                bromine1=typing.cast(Br, atoms[0]),
                 atom2=atoms[2],
-                bromine2=typing.cast(_elements.Br, atoms[3]),
+                bromine2=typing.cast(Br, atoms[3]),
                 bonders=tuple(atoms[i] for i in self._bonders),
                 deleters=tuple(atoms[i] for i in self._deleters),
                 placers=tuple(atoms[i] for i in self._placers),

--- a/src/stk/molecular/functional_groups/factories/difluoro_factory.py
+++ b/src/stk/molecular/functional_groups/factories/difluoro_factory.py
@@ -9,11 +9,11 @@ from __future__ import annotations
 import typing
 from collections import abc
 
-from . import functional_group_factory as _functional_group_factory
-from . import utilities as _utilities
-from .. import functional_groups as _functional_groups
-from ... import molecule as _molecule
-from ...atoms import elements as _elements
+from .functional_group_factory import FunctionalGroupFactory
+from .utilities import get_atom_ids
+from ..functional_groups import Difluoro
+from ...molecule import Molecule
+from ...atoms import F
 
 __all__ = (
     'DifluoroFactory',
@@ -22,9 +22,7 @@ __all__ = (
 _ValidIndex = typing.Literal[0, 1, 2, 3]
 
 
-class DifluoroFactory(
-    _functional_group_factory.FunctionalGroupFactory,
-):
+class DifluoroFactory(FunctionalGroupFactory):
     """
     Creates :class:`.Difluoro` instances.
 
@@ -143,19 +141,19 @@ class DifluoroFactory(
 
     def get_functional_groups(
         self,
-        molecule: _molecule.Molecule,
-    ) -> abc.Iterable[_functional_groups.Difluoro]:
+        molecule: Molecule,
+    ) -> abc.Iterable[Difluoro]:
 
-        for atom_ids in _utilities.get_atom_ids(
+        for atom_ids in get_atom_ids(
             query='[F][#6]~[#6][F]',
             molecule=molecule,
         ):
             atoms = tuple(molecule.get_atoms(atom_ids))
-            yield _functional_groups.Difluoro(
+            yield Difluoro(
                 atom1=atoms[1],
-                fluorine1=typing.cast(_elements.F, atoms[0]),
+                fluorine1=typing.cast(F, atoms[0]),
                 atom2=atoms[2],
-                fluorine2=typing.cast(_elements.F, atoms[3]),
+                fluorine2=typing.cast(F, atoms[3]),
                 bonders=tuple(atoms[i] for i in self._bonders),
                 deleters=tuple(atoms[i] for i in self._deleters),
                 placers=tuple(atoms[i] for i in self._placers),

--- a/src/stk/molecular/functional_groups/factories/diol_factory.py
+++ b/src/stk/molecular/functional_groups/factories/diol_factory.py
@@ -9,11 +9,11 @@ from __future__ import annotations
 import typing
 from collections import abc
 
-from . import functional_group_factory as _functional_group_factory
-from . import utilities as _utilities
-from .. import functional_groups as _functional_groups
-from ... import molecule as _molecule
-from ...atoms import elements as _elements
+from .functional_group_factory import FunctionalGroupFactory
+from .utilities import get_atom_ids
+from ..functional_groups import Diol
+from ...molecule import Molecule
+from ...atoms import O, H
 
 __all__ = (
     'DiolFactory',
@@ -22,9 +22,7 @@ __all__ = (
 _ValidIndex = typing.Literal[0, 1, 2, 3, 4, 5]
 
 
-class DiolFactory(
-    _functional_group_factory.FunctionalGroupFactory,
-):
+class DiolFactory(FunctionalGroupFactory):
     """
     Creates :class:`.Diol` instances.
 
@@ -143,21 +141,21 @@ class DiolFactory(
 
     def get_functional_groups(
         self,
-        molecule: _molecule.Molecule,
-    ) -> abc.Iterable[_functional_groups.Diol]:
+        molecule: Molecule,
+    ) -> abc.Iterable[Diol]:
 
-        for atom_ids in _utilities.get_atom_ids(
+        for atom_ids in get_atom_ids(
             query='[H][O][#6]~[#6][O][H]',
             molecule=molecule,
         ):
             atoms = tuple(molecule.get_atoms(atom_ids))
-            yield _functional_groups.Diol(
-                hydrogen1=typing.cast(_elements.H, atoms[0]),
-                oxygen1=typing.cast(_elements.O, atoms[1]),
+            yield Diol(
+                hydrogen1=typing.cast(H, atoms[0]),
+                oxygen1=typing.cast(O, atoms[1]),
                 atom1=atoms[2],
                 atom2=atoms[3],
-                oxygen2=typing.cast(_elements.O, atoms[4]),
-                hydrogen2=typing.cast(_elements.H, atoms[5]),
+                oxygen2=typing.cast(O, atoms[4]),
+                hydrogen2=typing.cast(H, atoms[5]),
                 bonders=tuple(atoms[i] for i in self._bonders),
                 deleters=tuple(atoms[i] for i in self._deleters),
                 placers=tuple(atoms[i] for i in self._placers),

--- a/src/stk/molecular/functional_groups/factories/fluoro_factory.py
+++ b/src/stk/molecular/functional_groups/factories/fluoro_factory.py
@@ -9,11 +9,11 @@ from __future__ import annotations
 import typing
 from collections import abc
 
-from . import functional_group_factory as _functional_group_factory
-from . import utilities as _utilities
-from .. import functional_groups as _functional_groups
-from ... import molecule as _molecule
-from ...atoms import elements as _elements
+from .functional_group_factory import FunctionalGroupFactory
+from .utilities import get_atom_ids
+from ..functional_groups import Fluoro
+from ...molecule import Molecule
+from ...atoms import F
 
 __all__ = (
     'FluoroFactory',
@@ -22,9 +22,7 @@ __all__ = (
 _ValidIndex = typing.Literal[0, 1]
 
 
-class FluoroFactory(
-    _functional_group_factory.FunctionalGroupFactory,
-):
+class FluoroFactory(FunctionalGroupFactory):
     """
     Creates :class:`.Fluoro` instances.
 
@@ -98,13 +96,13 @@ class FluoroFactory(
 
     def get_functional_groups(
         self,
-        molecule: _molecule.Molecule,
-    ) -> abc.Iterable[_functional_groups.Fluoro]:
+        molecule: Molecule,
+    ) -> abc.Iterable[Fluoro]:
 
-        for atom_ids in _utilities.get_atom_ids('[*][F]', molecule):
+        for atom_ids in get_atom_ids('[*][F]', molecule):
             atoms = tuple(molecule.get_atoms(atom_ids))
-            yield _functional_groups.Fluoro(
-                fluorine=typing.cast(_elements.F, atoms[1]),
+            yield Fluoro(
+                fluorine=typing.cast(F, atoms[1]),
                 atom=atoms[0],
                 bonders=tuple(atoms[i] for i in self._bonders),
                 deleters=tuple(atoms[i] for i in self._deleters),

--- a/src/stk/molecular/functional_groups/factories/functional_group_factory.py
+++ b/src/stk/molecular/functional_groups/factories/functional_group_factory.py
@@ -70,8 +70,8 @@ from __future__ import annotations
 
 from collections import abc
 
-from .. import functional_groups as _functional_groups
-from ... import molecule as _molecule
+from ..functional_groups import FunctionalGroup
+from ...molecule import Molecule
 
 
 class FunctionalGroupFactory:
@@ -161,8 +161,8 @@ class FunctionalGroupFactory:
 
     def get_functional_groups(
         self,
-        molecule: _molecule.Molecule,
-    ) -> abc.Iterable[_functional_groups.FunctionalGroup]:
+        molecule: Molecule,
+    ) -> abc.Iterable[FunctionalGroup]:
         """
         Yield functional groups in `molecule`.
 

--- a/src/stk/molecular/functional_groups/factories/iodo_factory.py
+++ b/src/stk/molecular/functional_groups/factories/iodo_factory.py
@@ -9,11 +9,11 @@ from __future__ import annotations
 import typing
 from collections import abc
 
-from . import functional_group_factory as _functional_group_factory
-from . import utilities as _utilities
-from .. import functional_groups as _functional_groups
-from ... import molecule as _molecule
-from ...atoms import elements as _elements
+from .functional_group_factory import FunctionalGroupFactory
+from .utilities import get_atom_ids
+from ..functional_groups import Iodo
+from ...molecule import Molecule
+from ...atoms import I
 
 __all__ = (
     'IodoFactory',
@@ -22,9 +22,7 @@ __all__ = (
 _ValidIndex = typing.Literal[0, 1]
 
 
-class IodoFactory(
-    _functional_group_factory.FunctionalGroupFactory,
-):
+class IodoFactory(FunctionalGroupFactory):
     """
     Creates :class:`.Iodo` instances.
 
@@ -98,13 +96,13 @@ class IodoFactory(
 
     def get_functional_groups(
         self,
-        molecule: _molecule.Molecule,
-    ) -> abc.Iterable[_functional_groups.Iodo]:
+        molecule: Molecule,
+    ) -> abc.Iterable[Iodo]:
 
-        for atom_ids in _utilities.get_atom_ids('[*][I]', molecule):
+        for atom_ids in get_atom_ids('[*][I]', molecule):
             atoms = tuple(molecule.get_atoms(atom_ids))
-            yield _functional_groups.Iodo(
-                iodine=typing.cast(_elements.I, atoms[1]),
+            yield Iodo(
+                iodine=typing.cast(I, atoms[1]),
                 atom=atoms[0],
                 bonders=tuple(atoms[i] for i in self._bonders),
                 deleters=tuple(atoms[i] for i in self._deleters),

--- a/src/stk/molecular/functional_groups/factories/primary_amino_factory.py
+++ b/src/stk/molecular/functional_groups/factories/primary_amino_factory.py
@@ -9,11 +9,11 @@ from __future__ import annotations
 import typing
 from collections import abc
 
-from . import functional_group_factory as _functional_group_factory
-from . import utilities as _utilities
-from .. import functional_groups as _functional_groups
-from ... import molecule as _molecule
-from ...atoms import elements as _elements
+from .functional_group_factory import FunctionalGroupFactory
+from .utilities import get_atom_ids
+from ..functional_groups import PrimaryAmino
+from ...molecule import Molecule
+from ...atoms import N, H
 
 __all__ = (
     'PrimaryAminoFactory',
@@ -22,9 +22,7 @@ __all__ = (
 _ValidIndex = typing.Literal[0, 1, 2, 3]
 
 
-class PrimaryAminoFactory(
-    _functional_group_factory.FunctionalGroupFactory,
-):
+class PrimaryAminoFactory(FunctionalGroupFactory):
     """
     Creates :class:`.PrimaryAmino` instances.
 
@@ -147,18 +145,18 @@ class PrimaryAminoFactory(
 
     def get_functional_groups(
         self,
-        molecule: _molecule.Molecule,
-    ) -> abc.Iterable[_functional_groups.PrimaryAmino]:
+        molecule: Molecule,
+    ) -> abc.Iterable[PrimaryAmino]:
 
-        for atom_ids in _utilities.get_atom_ids(
+        for atom_ids in get_atom_ids(
             query='[*][N]([H])[H]',
             molecule=molecule,
         ):
             atoms = tuple(molecule.get_atoms(atom_ids))
-            yield _functional_groups.PrimaryAmino(
-                nitrogen=typing.cast(_elements.N, atoms[1]),
-                hydrogen1=typing.cast(_elements.H, atoms[2]),
-                hydrogen2=typing.cast(_elements.H, atoms[3]),
+            yield PrimaryAmino(
+                nitrogen=typing.cast(N, atoms[1]),
+                hydrogen1=typing.cast(H, atoms[2]),
+                hydrogen2=typing.cast(H, atoms[3]),
                 atom=atoms[0],
                 bonders=tuple(atoms[i] for i in self._bonders),
                 deleters=tuple(atoms[i] for i in self._deleters),

--- a/src/stk/molecular/functional_groups/factories/ring_amine_factory.py
+++ b/src/stk/molecular/functional_groups/factories/ring_amine_factory.py
@@ -9,20 +9,18 @@ from __future__ import annotations
 import typing
 from collections import abc
 
-from . import functional_group_factory as _functional_group_factory
-from . import utilities as _utilities
-from .. import functional_groups as _functional_groups
-from ... import molecule as _molecule
-from ...atoms import elements as _elements
+from .functional_group_factory import FunctionalGroupFactory
+from .utilities import get_atom_ids
+from ..functional_groups import RingAmine
+from ...molecule import Molecule
+from ...atoms import N, C, H
 
 __all__ = (
     'RingAmineFactory',
 )
 
 
-class RingAmineFactory(
-    _functional_group_factory.FunctionalGroupFactory,
-):
+class RingAmineFactory(FunctionalGroupFactory):
     """
     Creates :class:`.RingAmine` functional groups.
 
@@ -43,20 +41,20 @@ class RingAmineFactory(
 
     def get_functional_groups(
         self,
-        molecule: _molecule.Molecule,
-    ) -> abc.Iterable[_functional_groups.RingAmine]:
+        molecule: Molecule,
+    ) -> abc.Iterable[RingAmine]:
 
-        for atom_ids in _utilities.get_atom_ids(
+        for atom_ids in get_atom_ids(
             query='[N]([H])([H])[#6]~[#6]([H])~[#6R1]',
             molecule=molecule,
         ):
             atoms = tuple(molecule.get_atoms(atom_ids))
-            yield _functional_groups.RingAmine(
-                nitrogen=typing.cast(_elements.N, atoms[0]),
-                hydrogen1=typing.cast(_elements.H, atoms[1]),
-                hydrogen2=typing.cast(_elements.H, atoms[2]),
-                carbon1=typing.cast(_elements.C, atoms[3]),
-                carbon2=typing.cast(_elements.C, atoms[4]),
-                hydrogen3=typing.cast(_elements.H, atoms[5]),
-                carbon3=typing.cast(_elements.C, atoms[6]),
+            yield RingAmine(
+                nitrogen=typing.cast(N, atoms[0]),
+                hydrogen1=typing.cast(H, atoms[1]),
+                hydrogen2=typing.cast(H, atoms[2]),
+                carbon1=typing.cast(C, atoms[3]),
+                carbon2=typing.cast(C, atoms[4]),
+                hydrogen3=typing.cast(H, atoms[5]),
+                carbon3=typing.cast(C, atoms[6]),
             )

--- a/src/stk/molecular/functional_groups/factories/secondary_amino_factory.py
+++ b/src/stk/molecular/functional_groups/factories/secondary_amino_factory.py
@@ -9,11 +9,11 @@ from __future__ import annotations
 import typing
 from collections import abc
 
-from . import functional_group_factory as _functional_group_factory
-from . import utilities as _utilities
-from .. import functional_groups as _functional_groups
-from ... import molecule as _molecule
-from ...atoms import elements as _elements
+from .functional_group_factory import FunctionalGroupFactory
+from .utilities import get_atom_ids
+from ..functional_groups import SecondaryAmino
+from ...molecule import Molecule
+from ...atoms import N, H
 
 
 __all__ = (
@@ -23,9 +23,7 @@ __all__ = (
 _ValidIndex = typing.Literal[0, 1, 2, 3]
 
 
-class SecondaryAminoFactory(
-    _functional_group_factory.FunctionalGroupFactory,
-):
+class SecondaryAminoFactory(FunctionalGroupFactory):
     """
     Creates :class:`.SecondaryAmino` instances.
 
@@ -145,16 +143,16 @@ class SecondaryAminoFactory(
 
     def get_functional_groups(
         self,
-        molecule: _molecule.Molecule,
-    ) -> abc.Iterable[_functional_groups.SecondaryAmino]:
-        for atom_ids in _utilities.get_atom_ids(
+        molecule: Molecule,
+    ) -> abc.Iterable[SecondaryAmino]:
+        for atom_ids in get_atom_ids(
             query='[H][N]([#6])[#6]',
             molecule=molecule,
         ):
             atoms = tuple(molecule.get_atoms(atom_ids))
-            yield _functional_groups.SecondaryAmino(
-                nitrogen=typing.cast(_elements.N, atoms[1]),
-                hydrogen=typing.cast(_elements.H, atoms[0]),
+            yield SecondaryAmino(
+                nitrogen=typing.cast(N, atoms[1]),
+                hydrogen=typing.cast(H, atoms[0]),
                 atom1=atoms[2],
                 atom2=atoms[3],
                 bonders=tuple(atoms[i] for i in self._bonders),

--- a/src/stk/molecular/functional_groups/factories/smarts_functional_group_factory.py
+++ b/src/stk/molecular/functional_groups/factories/smarts_functional_group_factory.py
@@ -9,10 +9,10 @@ from __future__ import annotations
 from typing import Optional
 from collections import abc
 
-from . import functional_group_factory as _functional_group_factory
-from . import utilities as _utilities
-from .. import functional_groups as _functional_groups
-from ... import molecule as _molecule
+from .functional_group_factory import FunctionalGroupFactory
+from .utilities import get_atom_ids
+from ..functional_groups import GenericFunctionalGroup
+from ...molecule import Molecule
 
 
 __all__ = (
@@ -20,9 +20,7 @@ __all__ = (
 )
 
 
-class SmartsFunctionalGroupFactory(
-    _functional_group_factory.FunctionalGroupFactory,
-):
+class SmartsFunctionalGroupFactory(FunctionalGroupFactory):
     """
     Creates :class:`.GenericFunctionalGroup` instances.
 
@@ -118,15 +116,15 @@ class SmartsFunctionalGroupFactory(
 
     def get_functional_groups(
         self,
-        molecule: _molecule.Molecule,
-    ) -> abc.Iterable[_functional_groups.GenericFunctionalGroup]:
+        molecule: Molecule,
+    ) -> abc.Iterable[GenericFunctionalGroup]:
 
-        for atom_ids in _utilities.get_atom_ids(
+        for atom_ids in get_atom_ids(
             query=self._smarts,
             molecule=molecule,
         ):
             atoms = tuple(molecule.get_atoms(atom_ids))
-            yield _functional_groups.GenericFunctionalGroup(
+            yield GenericFunctionalGroup(
                 atoms=atoms,
                 bonders=tuple(atoms[i] for i in self._bonders),
                 deleters=tuple(atoms[i] for i in self._deleters),

--- a/src/stk/molecular/functional_groups/factories/terminal_alkene_factory.py
+++ b/src/stk/molecular/functional_groups/factories/terminal_alkene_factory.py
@@ -9,11 +9,11 @@ from __future__ import annotations
 import typing
 from collections import abc
 
-from . import functional_group_factory as _functional_group_factory
-from . import utilities as _utilities
-from .. import functional_groups as _functional_groups
-from ... import molecule as _molecule
-from ...atoms import elements as _elements
+from .functional_group_factory import FunctionalGroupFactory
+from .utilities import get_atom_ids
+from ..functional_groups import Alkene
+from ...molecule import Molecule
+from ...atoms import C
 
 __all__ = (
     'TerminalAlkeneFactory',
@@ -22,9 +22,7 @@ __all__ = (
 _ValidIndex = typing.Literal[0, 1, 2, 3, 4, 5]
 
 
-class TerminalAlkeneFactory(
-    _functional_group_factory.FunctionalGroupFactory,
-):
+class TerminalAlkeneFactory(FunctionalGroupFactory):
     # This docstring is a literal string, to silence a flake8 warning
     # about CH\ :sub:`2`. It's taking the backslash out of context.
     r"""
@@ -140,19 +138,19 @@ class TerminalAlkeneFactory(
 
     def get_functional_groups(
         self,
-        molecule: _molecule.Molecule,
-    ) -> abc.Iterable[_functional_groups.Alkene]:
+        molecule: Molecule,
+    ) -> abc.Iterable[Alkene]:
 
-        for atom_ids in _utilities.get_atom_ids(
+        for atom_ids in get_atom_ids(
             query='[*][C]([*])=[C]([H])[H]',
             molecule=molecule,
         ):
             atoms = tuple(molecule.get_atoms(atom_ids))
-            yield _functional_groups.Alkene(
-                carbon1=typing.cast(_elements.C, atoms[1]),
+            yield Alkene(
+                carbon1=typing.cast(C, atoms[1]),
                 atom1=atoms[0],
                 atom2=atoms[2],
-                carbon2=typing.cast(_elements.C, atoms[3]),
+                carbon2=typing.cast(C, atoms[3]),
                 atom3=atoms[4],
                 atom4=atoms[5],
                 bonders=tuple(atoms[i] for i in self._bonders),

--- a/src/stk/molecular/functional_groups/factories/terminal_alkyne_factory.py
+++ b/src/stk/molecular/functional_groups/factories/terminal_alkyne_factory.py
@@ -9,11 +9,11 @@ from __future__ import annotations
 import typing
 from collections import abc
 
-from . import functional_group_factory as _functional_group_factory
-from . import utilities as _utilities
-from .. import functional_groups as _functional_groups
-from ... import molecule as _molecule
-from ...atoms import elements as _elements
+from .functional_group_factory import FunctionalGroupFactory
+from .utilities import get_atom_ids
+from ..functional_groups import Alkyne
+from ...molecule import Molecule
+from ...atoms import C
 
 
 __all__ = (
@@ -23,9 +23,7 @@ __all__ = (
 _ValidIndex = typing.Literal[0, 1, 2, 3]
 
 
-class TerminalAlkyneFactory(
-    _functional_group_factory.FunctionalGroupFactory,
-):
+class TerminalAlkyneFactory(FunctionalGroupFactory):
     """
     Creates :class:`.Alkyne` instances.
 
@@ -139,18 +137,18 @@ class TerminalAlkyneFactory(
 
     def get_functional_groups(
         self,
-        molecule: _molecule.Molecule,
-    ) -> abc.Iterable[_functional_groups.Alkyne]:
+        molecule: Molecule,
+    ) -> abc.Iterable[Alkyne]:
 
-        for atom_ids in _utilities.get_atom_ids(
+        for atom_ids in get_atom_ids(
             query='[*][C]#[C][H]',
             molecule=molecule,
         ):
             atoms = tuple(molecule.get_atoms(atom_ids))
-            yield _functional_groups.Alkyne(
+            yield Alkyne(
                 atom1=atoms[0],
-                carbon1=typing.cast(_elements.C, atoms[1]),
-                carbon2=typing.cast(_elements.C, atoms[2]),
+                carbon1=typing.cast(C, atoms[1]),
+                carbon2=typing.cast(C, atoms[2]),
                 atom2=atoms[3],
                 bonders=tuple(atoms[i] for i in self._bonders),
                 deleters=tuple(atoms[i] for i in self._deleters),

--- a/src/stk/molecular/functional_groups/factories/thioacid_factory.py
+++ b/src/stk/molecular/functional_groups/factories/thioacid_factory.py
@@ -9,11 +9,11 @@ from __future__ import annotations
 import typing
 from collections import abc
 
-from . import functional_group_factory as _functional_group_factory
-from . import utilities as _utilities
-from .. import functional_groups as _functional_groups
-from ... import molecule as _molecule
-from ...atoms import elements as _elements
+from .functional_group_factory import FunctionalGroupFactory
+from .utilities import get_atom_ids
+from ..functional_groups import Thioacid
+from ...molecule import Molecule
+from ...atoms import C, O, H, S
 
 __all__ = (
     'ThioacidFactory',
@@ -22,9 +22,7 @@ __all__ = (
 _ValidIndex = typing.Literal[0, 1, 2, 3, 4]
 
 
-class ThioacidFactory(
-    _functional_group_factory.FunctionalGroupFactory,
-):
+class ThioacidFactory(FunctionalGroupFactory):
     """
     Creates :class:`.Thioacid` instances.
 
@@ -141,19 +139,19 @@ class ThioacidFactory(
 
     def get_functional_groups(
         self,
-        molecule: _molecule.Molecule,
-    ) -> abc.Iterable[_functional_groups.Thioacid]:
+        molecule: Molecule,
+    ) -> abc.Iterable[Thioacid]:
 
-        for atom_ids in _utilities.get_atom_ids(
+        for atom_ids in get_atom_ids(
             query='[*][C](=[O])[S][H]',
             molecule=molecule,
         ):
             atoms = tuple(molecule.get_atoms(atom_ids))
-            yield _functional_groups.Thioacid(
-                carbon=typing.cast(_elements.C, atoms[1]),
-                oxygen=typing.cast(_elements.O, atoms[2]),
-                sulfur=typing.cast(_elements.S, atoms[3]),
-                hydrogen=typing.cast(_elements.H, atoms[4]),
+            yield Thioacid(
+                carbon=typing.cast(C, atoms[1]),
+                oxygen=typing.cast(O, atoms[2]),
+                sulfur=typing.cast(S, atoms[3]),
+                hydrogen=typing.cast(H, atoms[4]),
                 atom=atoms[0],
                 bonders=tuple(atoms[i] for i in self._bonders),
                 deleters=tuple(atoms[i] for i in self._deleters),

--- a/src/stk/molecular/functional_groups/factories/thiol_factory.py
+++ b/src/stk/molecular/functional_groups/factories/thiol_factory.py
@@ -9,11 +9,11 @@ from __future__ import annotations
 import typing
 from collections import abc
 
-from . import functional_group_factory as _functional_group_factory
-from . import utilities as _utilities
-from .. import functional_groups as _functional_groups
-from ... import molecule as _molecule
-from ...atoms import elements as _elements
+from .functional_group_factory import FunctionalGroupFactory
+from .utilities import get_atom_ids
+from ..functional_groups import Thiol
+from ...molecule import Molecule
+from ...atoms import S, H
 
 __all__ = (
     'ThiolFactory',
@@ -22,9 +22,7 @@ __all__ = (
 _ValidIndex = typing.Literal[0, 1, 2]
 
 
-class ThiolFactory(
-    _functional_group_factory.FunctionalGroupFactory,
-):
+class ThiolFactory(FunctionalGroupFactory):
     """
     Creates :class:`.Thiol` instances.
 
@@ -147,14 +145,14 @@ class ThiolFactory(
 
     def get_functional_groups(
         self,
-        molecule: _molecule.Molecule,
-    ) -> abc.Iterable[_functional_groups.Thiol]:
+        molecule: Molecule,
+    ) -> abc.Iterable[Thiol]:
 
-        for atom_ids in _utilities.get_atom_ids('[*][S][H]', molecule):
+        for atom_ids in get_atom_ids('[*][S][H]', molecule):
             atoms = tuple(molecule.get_atoms(atom_ids))
-            yield _functional_groups.Thiol(
-                sulfur=typing.cast(_elements.S, atoms[1]),
-                hydrogen=typing.cast(_elements.H, atoms[2]),
+            yield Thiol(
+                sulfur=typing.cast(S, atoms[1]),
+                hydrogen=typing.cast(H, atoms[2]),
                 atom=atoms[0],
                 bonders=tuple(atoms[i] for i in self._bonders),
                 deleters=tuple(atoms[i] for i in self._deleters),

--- a/src/stk/molecular/functional_groups/functional_groups/alcohol.py
+++ b/src/stk/molecular/functional_groups/functional_groups/alcohol.py
@@ -8,9 +8,9 @@ from __future__ import annotations
 
 import typing
 
-from . import utilities as _utilities
-from . import generic_functional_group as _generic_functional_group
-from ... import atoms as _atoms
+from .utilities import get_atom_map
+from .generic_functional_group import GenericFunctionalGroup
+from ...atoms import O, H, Atom
 
 
 __all__ = (
@@ -18,9 +18,7 @@ __all__ = (
 )
 
 
-class Alcohol(
-    _generic_functional_group.GenericFunctionalGroup,
-):
+class Alcohol(GenericFunctionalGroup):
     """
     Represents an alcohol functional group.
 
@@ -32,12 +30,12 @@ class Alcohol(
     def __init__(
         self,
         # O is not an ambiguous name.
-        oxygen: _atoms.O,  # noqa
-        hydrogen: _atoms.H,
-        atom: _atoms.Atom,
-        bonders: tuple[_atoms.Atom, ...],
-        deleters: tuple[_atoms.Atom, ...],
-        placers: typing.Optional[tuple[_atoms.Atom, ...]] = None,
+        oxygen: O,  # noqa
+        hydrogen: H,
+        atom: Atom,
+        bonders: tuple[Atom, ...],
+        deleters: tuple[Atom, ...],
+        placers: typing.Optional[tuple[Atom, ...]] = None,
     ) -> None:
         """
         Initialize a :class:`.Alcohol` instance.
@@ -65,7 +63,7 @@ class Alcohol(
 
         """
 
-        _generic_functional_group.GenericFunctionalGroup.__init__(
+        GenericFunctionalGroup.__init__(
             self=self,
             atoms=(oxygen, hydrogen, atom),
             bonders=bonders,
@@ -77,7 +75,7 @@ class Alcohol(
         self._atom = atom
 
     # O is not an ambiguous name.
-    def get_oxygen(self) -> _atoms.O:  # noqa
+    def get_oxygen(self) -> O:  # noqa
         """
         Get the oxygen atom.
 
@@ -89,7 +87,7 @@ class Alcohol(
 
         return self._oxygen
 
-    def get_hydrogen(self) -> _atoms.H:
+    def get_hydrogen(self) -> H:
         """
         Get the hydrogen atom.
 
@@ -101,7 +99,7 @@ class Alcohol(
 
         return self._hydrogen
 
-    def get_atom(self) -> _atoms.Atom:
+    def get_atom(self) -> Atom:
         """
         Get the atom to which the functional group is attached.
 
@@ -125,7 +123,7 @@ class Alcohol(
         id_map: dict[int, int],
     ) -> Alcohol:
 
-        atom_map = _utilities.get_atom_map(
+        atom_map = get_atom_map(
             id_map=id_map,
             atoms=(
                 *self._atoms,

--- a/src/stk/molecular/functional_groups/functional_groups/aldehyde.py
+++ b/src/stk/molecular/functional_groups/functional_groups/aldehyde.py
@@ -8,9 +8,9 @@ from __future__ import annotations
 
 import typing
 
-from . import utilities as _utilities
-from . import generic_functional_group as _generic_functional_group
-from ... import atoms as _atoms
+from .utilities import get_atom_map
+from .generic_functional_group import GenericFunctionalGroup
+from ...atoms import C, O, H, Atom
 
 
 __all__ = (
@@ -18,9 +18,7 @@ __all__ = (
 )
 
 
-class Aldehyde(
-    _generic_functional_group.GenericFunctionalGroup,
-):
+class Aldehyde(GenericFunctionalGroup):
     """
     Represents an aldehyde functional group.
 
@@ -31,14 +29,14 @@ class Aldehyde(
 
     def __init__(
         self,
-        carbon: _atoms.C,
+        carbon: C,
         # O is not an ambiguous name.
-        oxygen: _atoms.O,  # noqa
-        hydrogen: _atoms.H,
-        atom: _atoms.Atom,
-        bonders: tuple[_atoms.Atom, ...],
-        deleters: tuple[_atoms.Atom, ...],
-        placers: typing.Optional[tuple[_atoms.Atom, ...]] = None,
+        oxygen: O,  # noqa
+        hydrogen: H,
+        atom: Atom,
+        bonders: tuple[Atom, ...],
+        deleters: tuple[Atom, ...],
+        placers: typing.Optional[tuple[Atom, ...]] = None,
     ) -> None:
         """
         Initialize a :class:`.Aldehyde` instance.
@@ -69,7 +67,7 @@ class Aldehyde(
 
         """
 
-        _generic_functional_group.GenericFunctionalGroup.__init__(
+        GenericFunctionalGroup.__init__(
             self=self,
             atoms=(carbon, oxygen, hydrogen, atom),
             bonders=bonders,
@@ -81,7 +79,7 @@ class Aldehyde(
         self._hydrogen = hydrogen
         self._atom = atom
 
-    def get_carbon(self) -> _atoms.C:
+    def get_carbon(self) -> C:
         """
         Get the carbon atom.
 
@@ -105,7 +103,7 @@ class Aldehyde(
         """
         return self._oxygen
 
-    def get_hydrogen(self) -> _atoms.H:
+    def get_hydrogen(self) -> H:
         """
         Get the hydrogen atom.
 
@@ -117,7 +115,7 @@ class Aldehyde(
 
         return self._hydrogen
 
-    def get_atom(self) -> _atoms.Atom:
+    def get_atom(self) -> Atom:
         """
         Get the atom to which the functional group is attached.
 
@@ -134,7 +132,7 @@ class Aldehyde(
         id_map: dict[int, int],
     ) -> Aldehyde:
 
-        atom_map = _utilities.get_atom_map(
+        atom_map = get_atom_map(
             id_map=id_map,
             atoms=(
                 *self._atoms,

--- a/src/stk/molecular/functional_groups/functional_groups/alkene.py
+++ b/src/stk/molecular/functional_groups/functional_groups/alkene.py
@@ -8,9 +8,9 @@ from __future__ import annotations
 
 import typing
 
-from . import utilities as _utilities
-from . import generic_functional_group as _generic_functional_group
-from ... import atoms as _atoms
+from .utilities import get_atom_map
+from .generic_functional_group import GenericFunctionalGroup
+from ...atoms import C, Atom
 
 
 __all__ = (
@@ -18,9 +18,7 @@ __all__ = (
 )
 
 
-class Alkene(
-    _generic_functional_group.GenericFunctionalGroup,
-):
+class Alkene(GenericFunctionalGroup):
     """
     Represents an alkene functional group.
 
@@ -31,15 +29,15 @@ class Alkene(
 
     def __init__(
         self,
-        carbon1: _atoms.C,
-        atom1: _atoms.Atom,
-        atom2: _atoms.Atom,
-        carbon2: _atoms.C,
-        atom3: _atoms.Atom,
-        atom4: _atoms.Atom,
-        bonders: tuple[_atoms.Atom, ...],
-        deleters: tuple[_atoms.Atom, ...],
-        placers: typing.Optional[tuple[_atoms.Atom, ...]] = None,
+        carbon1: C,
+        atom1: Atom,
+        atom2: Atom,
+        carbon2: C,
+        atom3: Atom,
+        atom4: Atom,
+        bonders: tuple[Atom, ...],
+        deleters: tuple[Atom, ...],
+        placers: typing.Optional[tuple[Atom, ...]] = None,
     ) -> None:
         """
         Initialize a :class:`.Alkene` instance.
@@ -76,7 +74,7 @@ class Alkene(
 
         """
 
-        _generic_functional_group.GenericFunctionalGroup.__init__(
+        GenericFunctionalGroup.__init__(
             self=self,
             atoms=(carbon1, atom1, atom2, carbon2, atom3, atom4),
             bonders=bonders,
@@ -90,7 +88,7 @@ class Alkene(
         self._atom3 = atom3
         self._atom4 = atom4
 
-    def get_carbon1(self) -> _atoms.C:
+    def get_carbon1(self) -> C:
         """
         Get the ``[carbon1]`` atom.
 
@@ -102,7 +100,7 @@ class Alkene(
 
         return self._carbon1
 
-    def get_atom1(self) -> _atoms.Atom:
+    def get_atom1(self) -> Atom:
         """
         Get the ``[atom1]`` atom.
 
@@ -114,7 +112,7 @@ class Alkene(
 
         return self._atom1
 
-    def get_atom2(self) -> _atoms.Atom:
+    def get_atom2(self) -> Atom:
         """
         Get the ``[atom2]`` atom.
 
@@ -126,7 +124,7 @@ class Alkene(
 
         return self._atom2
 
-    def get_carbon2(self) -> _atoms.C:
+    def get_carbon2(self) -> C:
         """
         Get the ``[carbon2]`` atom.
 
@@ -138,7 +136,7 @@ class Alkene(
 
         return self._carbon2
 
-    def get_atom3(self) -> _atoms.Atom:
+    def get_atom3(self) -> Atom:
         """
         Get the ``[atom3]`` atom.
 
@@ -150,7 +148,7 @@ class Alkene(
 
         return self._atom3
 
-    def get_atom4(self) -> _atoms.Atom:
+    def get_atom4(self) -> Atom:
         """
         Get the ``[atom4]`` atom.
 
@@ -177,7 +175,7 @@ class Alkene(
         id_map: dict[int, int],
     ) -> Alkene:
 
-        atom_map = _utilities.get_atom_map(
+        atom_map = get_atom_map(
             id_map=id_map,
             atoms=(
                 *self._atoms,

--- a/src/stk/molecular/functional_groups/functional_groups/alkyne.py
+++ b/src/stk/molecular/functional_groups/functional_groups/alkyne.py
@@ -8,9 +8,9 @@ from __future__ import annotations
 
 import typing
 
-from . import utilities as _utilities
-from . import generic_functional_group as _generic_functional_group
-from ... import atoms as _atoms
+from .utilities import get_atom_map
+from .generic_functional_group import GenericFunctionalGroup
+from ...atoms import C, Atom
 
 
 __all__ = (
@@ -18,9 +18,7 @@ __all__ = (
 )
 
 
-class Alkyne(
-    _generic_functional_group.GenericFunctionalGroup,
-):
+class Alkyne(GenericFunctionalGroup):
     """
     Represents an alkyne functional group.
 
@@ -31,13 +29,13 @@ class Alkyne(
 
     def __init__(
         self,
-        carbon1: _atoms.C,
-        atom1: _atoms.Atom,
-        carbon2: _atoms.C,
-        atom2: _atoms.Atom,
-        bonders: tuple[_atoms.Atom, ...],
-        deleters: tuple[_atoms.Atom, ...],
-        placers: typing.Optional[tuple[_atoms.Atom, ...]] = None,
+        carbon1: C,
+        atom1: Atom,
+        carbon2: C,
+        atom2: Atom,
+        bonders: tuple[Atom, ...],
+        deleters: tuple[Atom, ...],
+        placers: typing.Optional[tuple[Atom, ...]] = None,
     ) -> None:
         """
         Initialize a :class:`.Alkyne` instance.
@@ -68,7 +66,7 @@ class Alkyne(
 
         """
 
-        _generic_functional_group.GenericFunctionalGroup.__init__(
+        GenericFunctionalGroup.__init__(
             self=self,
             atoms=(carbon1, atom1, carbon2, atom2),
             bonders=bonders,
@@ -80,7 +78,7 @@ class Alkyne(
         self._carbon2 = carbon2
         self._atom2 = atom2
 
-    def get_atom1(self) -> _atoms.Atom:
+    def get_atom1(self) -> Atom:
         """
         Get the ``[atom1]`` atom.
 
@@ -92,7 +90,7 @@ class Alkyne(
 
         return self._atom1
 
-    def get_carbon1(self) -> _atoms.C:
+    def get_carbon1(self) -> C:
         """
         Get the ``[carbon1]`` atom.
 
@@ -104,7 +102,7 @@ class Alkyne(
 
         return self._carbon1
 
-    def get_carbon2(self) -> _atoms.C:
+    def get_carbon2(self) -> C:
         """
         Get the ``[carbon2]`` atom.
 
@@ -116,7 +114,7 @@ class Alkyne(
 
         return self._carbon2
 
-    def get_atom2(self) -> _atoms.Atom:
+    def get_atom2(self) -> Atom:
         """
         Get the ``[atom2]`` atom.
 
@@ -141,7 +139,7 @@ class Alkyne(
         id_map: dict[int, int],
     ) -> Alkyne:
 
-        atom_map = _utilities.get_atom_map(
+        atom_map = get_atom_map(
             id_map=id_map,
             atoms=(
                 *self._atoms,

--- a/src/stk/molecular/functional_groups/functional_groups/amide.py
+++ b/src/stk/molecular/functional_groups/functional_groups/amide.py
@@ -8,9 +8,9 @@ from __future__ import annotations
 
 import typing
 
-from . import utilities as _utilities
-from . import generic_functional_group as _generic_functional_group
-from ... import atoms as _atoms
+from .utilities import get_atom_map
+from .generic_functional_group import GenericFunctionalGroup
+from ...atoms import O, C, N, H, Atom
 
 
 __all__ = (
@@ -18,9 +18,7 @@ __all__ = (
 )
 
 
-class Amide(
-    _generic_functional_group.GenericFunctionalGroup,
-):
+class Amide(GenericFunctionalGroup):
     """
     Represents an amide functional group.
 
@@ -31,16 +29,16 @@ class Amide(
 
     def __init__(
         self,
-        carbon: _atoms.C,
+        carbon: C,
         # O is not an ambiguous name.
-        oxygen: _atoms.O,  # noqa
-        nitrogen: _atoms.N,
-        hydrogen1: _atoms.H,
-        hydrogen2: _atoms.H,
-        atom: _atoms.Atom,
-        bonders: tuple[_atoms.Atom, ...],
-        deleters: tuple[_atoms.Atom, ...],
-        placers: typing.Optional[tuple[_atoms.Atom, ...]] = None,
+        oxygen: O,  # noqa
+        nitrogen: N,
+        hydrogen1: H,
+        hydrogen2: H,
+        atom: Atom,
+        bonders: tuple[Atom, ...],
+        deleters: tuple[Atom, ...],
+        placers: typing.Optional[tuple[Atom, ...]] = None,
     ) -> None:
         """
         Initialize a :class:`.Amide` instance.
@@ -77,7 +75,7 @@ class Amide(
 
         """
 
-        _generic_functional_group.GenericFunctionalGroup.__init__(
+        GenericFunctionalGroup.__init__(
             self=self,
             atoms=(
                 carbon,
@@ -98,7 +96,7 @@ class Amide(
         self._hydrogen2 = hydrogen2
         self._atom = atom
 
-    def get_carbon(self) -> _atoms.C:
+    def get_carbon(self) -> C:
         """
         Get the ``[carbon]`` atom.
 
@@ -111,7 +109,7 @@ class Amide(
         return self._carbon
 
     # O is not an ambiguous name.
-    def get_oxygen(self) -> _atoms.O:  # noqa
+    def get_oxygen(self) -> O:  # noqa
         """
         Get the ``[oxygen]`` atom.
 
@@ -123,7 +121,7 @@ class Amide(
 
         return self._oxygen
 
-    def get_nitrogen(self) -> _atoms.N:
+    def get_nitrogen(self) -> N:
         """
         Get the ``[nitrogen]`` atom.
 
@@ -135,7 +133,7 @@ class Amide(
 
         return self._nitrogen
 
-    def get_hydrogen1(self) -> _atoms.H:
+    def get_hydrogen1(self) -> H:
         """
         Get the ``[hydrogen1]`` atom.
 
@@ -147,7 +145,7 @@ class Amide(
 
         return self._hydrogen1
 
-    def get_hydrogen2(self) -> _atoms.H:
+    def get_hydrogen2(self) -> H:
         """
         Get the ``[hydrogen2]`` atom.
 
@@ -159,7 +157,7 @@ class Amide(
 
         return self._hydrogen2
 
-    def get_atom(self) -> _atoms.Atom:
+    def get_atom(self) -> Atom:
         """
         Get the ``[atom]`` atom.
 
@@ -186,7 +184,7 @@ class Amide(
         id_map: dict[int, int],
     ) -> Amide:
 
-        atom_map = _utilities.get_atom_map(
+        atom_map = get_atom_map(
             id_map=id_map,
             atoms=(
                 *self._atoms,

--- a/src/stk/molecular/functional_groups/functional_groups/boronic_acid.py
+++ b/src/stk/molecular/functional_groups/functional_groups/boronic_acid.py
@@ -8,18 +8,16 @@ from __future__ import annotations
 
 import typing
 
-from . import utilities as _utilities
-from . import generic_functional_group as _generic_functional_group
-from ... import atoms as _atoms
+from .utilities import get_atom_map
+from .generic_functional_group import GenericFunctionalGroup
+from ...atoms import B, O, H, Atom
 
 __all__ = (
     'BoronicAcid',
 )
 
 
-class BoronicAcid(
-    _generic_functional_group.GenericFunctionalGroup,
-):
+class BoronicAcid(GenericFunctionalGroup):
     """
     Represents a boronic acid functional group.
 
@@ -30,17 +28,17 @@ class BoronicAcid(
 
     def __init__(
         self,
-        boron: _atoms.B,
+        boron: B,
         # O is not an ambiguous name.
-        oxygen1: _atoms.O,  # noqa
-        hydrogen1: _atoms.H,
+        oxygen1: O,  # noqa
+        hydrogen1: H,
         # O is not an ambiguous name.
-        oxygen2: _atoms.O,  # noqa
-        hydrogen2: _atoms.H,
-        atom: _atoms.Atom,
-        bonders: tuple[_atoms.Atom, ...],
-        deleters: tuple[_atoms.Atom, ...],
-        placers: typing.Optional[tuple[_atoms.Atom, ...]] = None,
+        oxygen2: O,  # noqa
+        hydrogen2: H,
+        atom: Atom,
+        bonders: tuple[Atom, ...],
+        deleters: tuple[Atom, ...],
+        placers: typing.Optional[tuple[Atom, ...]] = None,
     ) -> None:
         """
         Initialize a :class:`.BoronicAcid` instance.
@@ -77,7 +75,7 @@ class BoronicAcid(
 
         """
 
-        _generic_functional_group.GenericFunctionalGroup.__init__(
+        GenericFunctionalGroup.__init__(
             self=self,
             atoms=(
                 boron,
@@ -98,7 +96,7 @@ class BoronicAcid(
         self._hydrogen2 = hydrogen2
         self._atom = atom
 
-    def get_boron(self) -> _atoms.B:
+    def get_boron(self) -> B:
         """
         Get the ``[boron]`` atom.
 
@@ -111,7 +109,7 @@ class BoronicAcid(
         return self._boron
 
     # O is not an ambiguous name.
-    def get_oxygen1(self) -> _atoms.O:  # noqa
+    def get_oxygen1(self) -> O:  # noqa
         """
         Get the ``[oxygen1]`` atom.
 
@@ -123,7 +121,7 @@ class BoronicAcid(
 
         return self._oxygen1
 
-    def get_hydrogen1(self) -> _atoms.H:
+    def get_hydrogen1(self) -> H:
         """
         Get the ``[hydrogen1]`` atom.
 
@@ -136,7 +134,7 @@ class BoronicAcid(
         return self._hydrogen1
 
     # O is not an ambiguous name.
-    def get_oxygen2(self) -> _atoms.O:  # noqa
+    def get_oxygen2(self) -> O:  # noqa
         """
         Get the ``[oxygen2]`` atom.
 
@@ -148,7 +146,7 @@ class BoronicAcid(
 
         return self._oxygen2
 
-    def get_hydrogen2(self) -> _atoms.H:
+    def get_hydrogen2(self) -> H:
         """
         Get the ``[hydrogen2]`` atom.
 
@@ -160,7 +158,7 @@ class BoronicAcid(
 
         return self._hydrogen2
 
-    def get_atom(self) -> _atoms.Atom:
+    def get_atom(self) -> Atom:
         """
         Get the ``[atom]`` atom.
 
@@ -187,7 +185,7 @@ class BoronicAcid(
         id_map: dict[int, int],
     ) -> BoronicAcid:
 
-        atom_map = _utilities.get_atom_map(
+        atom_map = get_atom_map(
             id_map=id_map,
             atoms=(
                 *self._atoms,

--- a/src/stk/molecular/functional_groups/functional_groups/bromo.py
+++ b/src/stk/molecular/functional_groups/functional_groups/bromo.py
@@ -8,9 +8,9 @@ from __future__ import annotations
 
 import typing
 
-from . import utilities as _utilities
-from . import generic_functional_group as _generic_functional_group
-from ... import atoms as _atoms
+from .utilities import get_atom_map
+from .generic_functional_group import GenericFunctionalGroup
+from ...atoms import Br, Atom
 
 
 __all__ = (
@@ -18,9 +18,7 @@ __all__ = (
 )
 
 
-class Bromo(
-    _generic_functional_group.GenericFunctionalGroup,
-):
+class Bromo(GenericFunctionalGroup):
     """
     Represents a bromo functional group.
 
@@ -31,11 +29,11 @@ class Bromo(
 
     def __init__(
         self,
-        bromine: _atoms.Br,
-        atom: _atoms.Atom,
-        bonders: tuple[_atoms.Atom, ...],
-        deleters: tuple[_atoms.Atom, ...],
-        placers: typing.Optional[tuple[_atoms.Atom, ...]] = None,
+        bromine: Br,
+        atom: Atom,
+        bonders: tuple[Atom, ...],
+        deleters: tuple[Atom, ...],
+        placers: typing.Optional[tuple[Atom, ...]] = None,
     ) -> None:
         """
         Initialize a :class:`.Bromo` instance.
@@ -60,7 +58,7 @@ class Bromo(
 
         """
 
-        _generic_functional_group.GenericFunctionalGroup.__init__(
+        GenericFunctionalGroup.__init__(
             self=self,
             atoms=(bromine, atom),
             bonders=bonders,
@@ -70,7 +68,7 @@ class Bromo(
         self._bromine = bromine
         self._atom = atom
 
-    def get_bromine(self) -> _atoms.Br:
+    def get_bromine(self) -> Br:
         """
         Get the ``[bromine]`` atom.
 
@@ -82,7 +80,7 @@ class Bromo(
 
         return self._bromine
 
-    def get_atom(self) -> _atoms.Atom:
+    def get_atom(self) -> Atom:
         """
         Get the ``[atom]`` atom.
 
@@ -105,7 +103,7 @@ class Bromo(
         id_map: dict[int, int],
     ) -> Bromo:
 
-        atom_map = _utilities.get_atom_map(
+        atom_map = get_atom_map(
             id_map=id_map,
             atoms=(
                 *self._atoms,

--- a/src/stk/molecular/functional_groups/functional_groups/carboxylic_acid.py
+++ b/src/stk/molecular/functional_groups/functional_groups/carboxylic_acid.py
@@ -8,9 +8,9 @@ from __future__ import annotations
 
 import typing
 
-from . import utilities as _utilities
-from . import generic_functional_group as _generic_functional_group
-from ... import atoms as _atoms
+from .utilities import get_atom_map
+from .generic_functional_group import GenericFunctionalGroup
+from ...atoms import C, O, H, Atom
 
 
 __all__ = (
@@ -18,9 +18,7 @@ __all__ = (
 )
 
 
-class CarboxylicAcid(
-    _generic_functional_group.GenericFunctionalGroup,
-):
+class CarboxylicAcid(GenericFunctionalGroup):
     """
     Represents a carboxylic acid functional group.
 
@@ -31,16 +29,16 @@ class CarboxylicAcid(
 
     def __init__(
         self,
-        carbon: _atoms.C,
+        carbon: C,
         # O is not an ambiguous name.
-        oxygen1: _atoms.O,  # noqa
+        oxygen1: O,  # noqa
         # O is not an ambiguous name.
-        oxygen2: _atoms.O,  # noqa
-        hydrogen: _atoms.H,
-        atom: _atoms.Atom,
-        bonders: tuple[_atoms.Atom, ...],
-        deleters: tuple[_atoms.Atom, ...],
-        placers: typing.Optional[tuple[_atoms.Atom, ...]] = None,
+        oxygen2: O,  # noqa
+        hydrogen: H,
+        atom: Atom,
+        bonders: tuple[Atom, ...],
+        deleters: tuple[Atom, ...],
+        placers: typing.Optional[tuple[Atom, ...]] = None,
     ):
         """
         Initialize a :class:`.CarboxylicAcid` instance.
@@ -74,7 +72,7 @@ class CarboxylicAcid(
 
         """
 
-        _generic_functional_group.GenericFunctionalGroup.__init__(
+        GenericFunctionalGroup.__init__(
             self=self,
             atoms=(carbon, oxygen1, oxygen2, hydrogen, atom),
             bonders=bonders,
@@ -87,7 +85,7 @@ class CarboxylicAcid(
         self._hydrogen = hydrogen
         self._atom = atom
 
-    def get_carbon(self) -> _atoms.C:
+    def get_carbon(self) -> C:
         """
         Get the ``[carbon]`` atom.
 
@@ -100,7 +98,7 @@ class CarboxylicAcid(
         return self._carbon
 
     # O is not an ambiguous name.
-    def get_oxygen1(self) -> _atoms.O:  # noqa
+    def get_oxygen1(self) -> O:  # noqa
         """
         Get the ``[oxygen1]`` atom.
 
@@ -113,7 +111,7 @@ class CarboxylicAcid(
         return self._oxygen1
 
     # O is not an ambiguous name.
-    def get_oxygen2(self):  # noqa
+    def get_oxygen2(self) -> O:   # noqa
         """
         Get the ``[oxygen2]`` atom.
 
@@ -125,7 +123,7 @@ class CarboxylicAcid(
 
         return self._oxygen2
 
-    def get_hydrogen(self) -> _atoms.H:
+    def get_hydrogen(self) -> H:
         """
         Get the ``[hydrogen]`` atom.
 
@@ -137,7 +135,7 @@ class CarboxylicAcid(
 
         return self._hydrogen
 
-    def get_atom(self) -> _atoms.Atom:
+    def get_atom(self) -> Atom:
         """
         Get the ``[atom]`` atom.
 
@@ -163,7 +161,7 @@ class CarboxylicAcid(
         id_map: dict[int, int],
     ) -> CarboxylicAcid:
 
-        atom_map = _utilities.get_atom_map(
+        atom_map = get_atom_map(
             id_map=id_map,
             atoms=(
                 *self._atoms,

--- a/src/stk/molecular/functional_groups/functional_groups/dibromo.py
+++ b/src/stk/molecular/functional_groups/functional_groups/dibromo.py
@@ -8,9 +8,9 @@ from __future__ import annotations
 
 import typing
 
-from . import utilities as _utilities
-from . import generic_functional_group as _generic_functional_group
-from ... import atoms as _atoms
+from .utilities import get_atom_map
+from .generic_functional_group import GenericFunctionalGroup
+from ...atoms import Br, Atom
 
 
 __all__ = (
@@ -18,9 +18,7 @@ __all__ = (
 )
 
 
-class Dibromo(
-    _generic_functional_group.GenericFunctionalGroup,
-):
+class Dibromo(GenericFunctionalGroup):
     """
     Represents a dibromo functional group.
 
@@ -31,13 +29,13 @@ class Dibromo(
 
     def __init__(
         self,
-        bromine1: _atoms.Br,
-        atom1: _atoms.Atom,
-        bromine2: _atoms.Br,
-        atom2: _atoms.Atom,
-        bonders: tuple[_atoms.Atom, ...],
-        deleters: tuple[_atoms.Atom, ...],
-        placers: typing.Optional[tuple[_atoms.Atom, ...]] = None,
+        bromine1: Br,
+        atom1: Atom,
+        bromine2: Br,
+        atom2: Atom,
+        bonders: tuple[Atom, ...],
+        deleters: tuple[Atom, ...],
+        placers: typing.Optional[tuple[Atom, ...]] = None,
     ) -> None:
         """
         Initialize a :class:`.Dibromo` instance.
@@ -68,7 +66,7 @@ class Dibromo(
 
         """
 
-        _generic_functional_group.GenericFunctionalGroup.__init__(
+        GenericFunctionalGroup.__init__(
             self=self,
             atoms=(bromine1, atom1, bromine2, atom2),
             bonders=bonders,
@@ -80,7 +78,7 @@ class Dibromo(
         self._bromine2 = bromine2
         self._atom2 = atom2
 
-    def get_atom1(self) -> _atoms.Atom:
+    def get_atom1(self) -> Atom:
         """
         Get the ``[atom1]`` atom.
 
@@ -92,7 +90,7 @@ class Dibromo(
 
         return self._atom1
 
-    def get_bromine1(self) -> _atoms.Br:
+    def get_bromine1(self) -> Br:
         """
         Get the ``[bromine1]`` atom.
 
@@ -104,7 +102,7 @@ class Dibromo(
 
         return self._bromine1
 
-    def get_atom2(self) -> _atoms.Atom:
+    def get_atom2(self) -> Atom:
         """
         Get the ``[atom2]`` atom.
 
@@ -116,7 +114,7 @@ class Dibromo(
 
         return self._atom2
 
-    def get_bromine2(self) -> _atoms.Br:
+    def get_bromine2(self) -> Br:
         """
         Get the ``[bromine2]`` atom.
 
@@ -141,7 +139,7 @@ class Dibromo(
         id_map: dict[int, int],
     ) -> Dibromo:
 
-        atom_map = _utilities.get_atom_map(
+        atom_map = get_atom_map(
             id_map=id_map,
             atoms=(
                 *self._atoms,

--- a/src/stk/molecular/functional_groups/functional_groups/difluoro.py
+++ b/src/stk/molecular/functional_groups/functional_groups/difluoro.py
@@ -8,9 +8,9 @@ from __future__ import annotations
 
 import typing
 
-from . import utilities as _utilities
-from . import generic_functional_group as _generic_functional_group
-from ... import atoms as _atoms
+from .utilities import get_atom_map
+from .generic_functional_group import GenericFunctionalGroup
+from ...atoms import F, Atom
 
 
 __all__ = (
@@ -18,9 +18,7 @@ __all__ = (
 )
 
 
-class Difluoro(
-    _generic_functional_group.GenericFunctionalGroup,
-):
+class Difluoro(GenericFunctionalGroup):
     """
     Represents a difluoro functional group.
 
@@ -31,13 +29,13 @@ class Difluoro(
 
     def __init__(
         self,
-        fluorine1: _atoms.F,
-        atom1: _atoms.Atom,
-        fluorine2: _atoms.F,
-        atom2: _atoms.Atom,
-        bonders: tuple[_atoms.Atom, ...],
-        deleters: tuple[_atoms.Atom, ...],
-        placers: typing.Optional[tuple[_atoms.Atom, ...]] = None,
+        fluorine1: F,
+        atom1: Atom,
+        fluorine2: F,
+        atom2: Atom,
+        bonders: tuple[Atom, ...],
+        deleters: tuple[Atom, ...],
+        placers: typing.Optional[tuple[Atom, ...]] = None,
     ) -> None:
         """
         Initialize a :class:`.Difluoro` instance.
@@ -62,7 +60,7 @@ class Difluoro(
 
         """
 
-        _generic_functional_group.GenericFunctionalGroup.__init__(
+        GenericFunctionalGroup.__init__(
             self=self,
             atoms=(fluorine1, atom1, fluorine2, atom2),
             bonders=bonders,
@@ -74,7 +72,7 @@ class Difluoro(
         self._fluorine2 = fluorine2
         self._atom2 = atom2
 
-    def get_atom1(self) -> _atoms.Atom:
+    def get_atom1(self) -> Atom:
         """
         Get the ``[atom1]`` atom.
 
@@ -86,7 +84,7 @@ class Difluoro(
 
         return self._atom1
 
-    def get_fluorine1(self) -> _atoms.F:
+    def get_fluorine1(self) -> F:
         """
         Get the ``[fluorine1]`` atom.
 
@@ -98,7 +96,7 @@ class Difluoro(
 
         return self._fluorine1
 
-    def get_atom2(self) -> _atoms.Atom:
+    def get_atom2(self) -> Atom:
         """
         Get the ``[atom2]`` atom.
 
@@ -110,7 +108,7 @@ class Difluoro(
 
         return self._atom2
 
-    def get_fluorine2(self) -> _atoms.F:
+    def get_fluorine2(self) -> F:
         """
         Get the ``[fluorine2]`` atom.
 
@@ -127,7 +125,7 @@ class Difluoro(
         id_map: dict[int, int],
     ) -> Difluoro:
 
-        atom_map = _utilities.get_atom_map(
+        atom_map = get_atom_map(
             id_map=id_map,
             atoms=(
                 *self._atoms,

--- a/src/stk/molecular/functional_groups/functional_groups/diol.py
+++ b/src/stk/molecular/functional_groups/functional_groups/diol.py
@@ -8,9 +8,9 @@ from __future__ import annotations
 
 import typing
 
-from . import utilities as _utilities
-from . import generic_functional_group as _generic_functional_group
-from ... import atoms as _atoms
+from .utilities import get_atom_map
+from .generic_functional_group import GenericFunctionalGroup
+from ...atoms import O, H, Atom
 
 
 __all__ = (
@@ -18,9 +18,7 @@ __all__ = (
 )
 
 
-class Diol(
-    _generic_functional_group.GenericFunctionalGroup,
-):
+class Diol(GenericFunctionalGroup):
     """
     Represents a diol functional group.
 
@@ -31,17 +29,17 @@ class Diol(
 
     def __init__(
         self,
-        atom1: _atoms.Atom,
+        atom1: Atom,
         # O is not an ambiguous name.
-        oxygen1: _atoms.O,  # noqa
-        hydrogen1: _atoms.H,
-        atom2: _atoms.Atom,
+        oxygen1: O,  # noqa
+        hydrogen1: H,
+        atom2: Atom,
         # O is not an ambiguous name.
-        oxygen2: _atoms.O,  # noqa
-        hydrogen2: _atoms.H,
-        bonders: tuple[_atoms.Atom, ...],
-        deleters: tuple[_atoms.Atom, ...],
-        placers: typing.Optional[tuple[_atoms.Atom, ...]] = None,
+        oxygen2: O,  # noqa
+        hydrogen2: H,
+        bonders: tuple[Atom, ...],
+        deleters: tuple[Atom, ...],
+        placers: typing.Optional[tuple[Atom, ...]] = None,
     ):
         """
         Initialize a :class:`.Diol` instance.
@@ -78,7 +76,7 @@ class Diol(
 
         """
 
-        _generic_functional_group.GenericFunctionalGroup.__init__(
+        GenericFunctionalGroup.__init__(
             self=self,
             atoms=(
                 atom1,
@@ -99,7 +97,7 @@ class Diol(
         self._oxygen2 = oxygen2
         self._hydrogen2 = hydrogen2
 
-    def get_atom1(self) -> _atoms.Atom:
+    def get_atom1(self) -> Atom:
         """
         Get the ``[atom1]`` atom.
 
@@ -112,7 +110,7 @@ class Diol(
         return self._atom1
 
     # O is not an ambiguous name.
-    def get_oxygen1(self) -> _atoms.O:  # noqa
+    def get_oxygen1(self) -> O:  # noqa
         """
         Get the ``[oxygen1]`` atom.
 
@@ -124,7 +122,7 @@ class Diol(
 
         return self._oxygen1
 
-    def get_hydrogen1(self) -> _atoms.H:
+    def get_hydrogen1(self) -> H:
         """
         Get the ``[hydrogen1]`` atom.
 
@@ -136,7 +134,7 @@ class Diol(
 
         return self._hydrogen1
 
-    def get_atom2(self) -> _atoms.Atom:
+    def get_atom2(self) -> Atom:
         """
         Get the ``[atom2]`` atom.
 
@@ -149,7 +147,7 @@ class Diol(
         return self._atom2
 
     # O is not an ambiguous name.
-    def get_oxygen2(self) -> _atoms.O:  # noqa
+    def get_oxygen2(self) -> O:  # noqa
         """
         Get the ``[oxygen2]`` atom.
 
@@ -161,7 +159,7 @@ class Diol(
 
         return self._oxygen2
 
-    def get_hydrogen2(self) -> _atoms.H:
+    def get_hydrogen2(self) -> H:
         """
         Get the ``[hydrogen2]`` atom.
 
@@ -188,7 +186,7 @@ class Diol(
         id_map: dict[int, int],
     ) -> Diol:
 
-        atom_map = _utilities.get_atom_map(
+        atom_map = get_atom_map(
             id_map=id_map,
             atoms=(
                 *self._atoms,

--- a/src/stk/molecular/functional_groups/functional_groups/fluoro.py
+++ b/src/stk/molecular/functional_groups/functional_groups/fluoro.py
@@ -8,9 +8,9 @@ from __future__ import annotations
 
 import typing
 
-from . import utilities as _utilities
-from . import generic_functional_group as _generic_functional_group
-from ... import atoms as _atoms
+from .utilities import get_atom_map
+from .generic_functional_group import GenericFunctionalGroup
+from ...atoms import F, Atom
 
 
 __all__ = (
@@ -18,9 +18,7 @@ __all__ = (
 )
 
 
-class Fluoro(
-    _generic_functional_group.GenericFunctionalGroup,
-):
+class Fluoro(GenericFunctionalGroup):
     """
     Represents a fluoro functional group.
 
@@ -31,11 +29,11 @@ class Fluoro(
 
     def __init__(
         self,
-        fluorine: _atoms.F,
-        atom: _atoms.Atom,
-        bonders: tuple[_atoms.Atom, ...],
-        deleters: tuple[_atoms.Atom, ...],
-        placers: typing.Optional[tuple[_atoms.Atom, ...]] = None,
+        fluorine: F,
+        atom: Atom,
+        bonders: tuple[Atom, ...],
+        deleters: tuple[Atom, ...],
+        placers: typing.Optional[tuple[Atom, ...]] = None,
     ) -> None:
         """
         Initialize a :class:`.Fluoro` instance.
@@ -60,7 +58,7 @@ class Fluoro(
 
         """
 
-        _generic_functional_group.GenericFunctionalGroup.__init__(
+        GenericFunctionalGroup.__init__(
             self=self,
             atoms=(fluorine, atom),
             bonders=bonders,
@@ -70,7 +68,7 @@ class Fluoro(
         self._fluorine = fluorine
         self._atom = atom
 
-    def get_fluorine(self) -> _atoms.F:
+    def get_fluorine(self) -> F:
         """
         Get the ``[fluorine]`` atom.
 
@@ -82,7 +80,7 @@ class Fluoro(
 
         return self._fluorine
 
-    def get_atom(self) -> _atoms.Atom:
+    def get_atom(self) -> Atom:
         """
         Get the ``[atom]`` atom.
 
@@ -104,7 +102,7 @@ class Fluoro(
         self,
         id_map: dict[int, int],
     ) -> Fluoro:
-        atom_map = _utilities.get_atom_map(
+        atom_map = get_atom_map(
             id_map=id_map,
             atoms=(
                 *self._atoms,

--- a/src/stk/molecular/functional_groups/functional_groups/functional_group.py
+++ b/src/stk/molecular/functional_groups/functional_groups/functional_group.py
@@ -64,8 +64,8 @@ from __future__ import annotations
 import typing
 from collections import abc
 
-from . import utilities as _utilities
-from ... import atoms as _atoms
+from .utilities import get_atom_map
+from ...atoms import Atom
 
 
 __all__ = (
@@ -248,9 +248,9 @@ class FunctionalGroup:
 
     def __init__(
         self,
-        atoms: tuple[_atoms.Atom, ...],
-        placers: tuple[_atoms.Atom, ...],
-        core_atoms: tuple[_atoms.Atom, ...],
+        atoms: tuple[Atom, ...],
+        placers: tuple[Atom, ...],
+        core_atoms: tuple[Atom, ...],
     ) -> None:
         """
         Initialize a :class:`.FunctionalGroup`.
@@ -275,7 +275,7 @@ class FunctionalGroup:
         self._placers = placers
         self._core_atoms = core_atoms
 
-    def get_atoms(self) -> abc.Iterable[_atoms.Atom]:
+    def get_atoms(self) -> abc.Iterable[Atom]:
         """
         Yield all the atoms in the functional group.
 
@@ -333,7 +333,7 @@ class FunctionalGroup:
 
     def with_atoms(
         self,
-        atom_map: dict[int, _atoms.Atom],
+        atom_map: dict[int, Atom],
     ) -> FunctionalGroup:
         """
         Return a clone holding different atoms.
@@ -388,7 +388,7 @@ class FunctionalGroup:
 
         """
 
-        atom_map = _utilities.get_atom_map(
+        atom_map = get_atom_map(
             id_map=id_map,
             atoms=(
                 *self._atoms,

--- a/src/stk/molecular/functional_groups/functional_groups/generic_functional_group.py
+++ b/src/stk/molecular/functional_groups/functional_groups/generic_functional_group.py
@@ -10,9 +10,9 @@ from __future__ import annotations
 import typing
 from collections import abc
 
-from . import functional_group as _functional_group
-from . import utilities as _utilities
-from ... import atoms as _atoms
+from .functional_group import FunctionalGroup
+from .utilities import get_atom_map
+from ...atoms import Atom
 
 
 __all__ = (
@@ -23,7 +23,7 @@ __all__ = (
 _T = typing.TypeVar('_T', bound='GenericFunctionalGroup')
 
 
-class GenericFunctionalGroup(_functional_group.FunctionalGroup):
+class GenericFunctionalGroup(FunctionalGroup):
     """
     A functional group which defines general atomic classes.
 
@@ -39,10 +39,10 @@ class GenericFunctionalGroup(_functional_group.FunctionalGroup):
 
     def __init__(
         self,
-        atoms: tuple[_atoms.Atom, ...],
-        bonders: tuple[_atoms.Atom, ...],
-        deleters: tuple[_atoms.Atom, ...],
-        placers: typing.Optional[tuple[_atoms.Atom, ...]] = None,
+        atoms: tuple[Atom, ...],
+        bonders: tuple[Atom, ...],
+        deleters: tuple[Atom, ...],
+        placers: typing.Optional[tuple[Atom, ...]] = None,
     ) -> None:
         """
         Initialize a :class:`.GenericFunctionalGroup`.
@@ -65,7 +65,7 @@ class GenericFunctionalGroup(_functional_group.FunctionalGroup):
         """
 
         deleter_set = set(atom.get_id() for atom in deleters)
-        _functional_group.FunctionalGroup.__init__(
+        FunctionalGroup.__init__(
             self=self,
             atoms=atoms,
             placers=bonders if placers is None else placers,
@@ -88,7 +88,7 @@ class GenericFunctionalGroup(_functional_group.FunctionalGroup):
 
     def with_atoms(
         self,
-        atom_map: dict[int, _atoms.Atom],
+        atom_map: dict[int, Atom],
     ) -> GenericFunctionalGroup:
 
         clone = GenericFunctionalGroup.__new__(GenericFunctionalGroup)
@@ -114,7 +114,7 @@ class GenericFunctionalGroup(_functional_group.FunctionalGroup):
         id_map: dict[int, int],
     ) -> GenericFunctionalGroup:
 
-        atom_map = _utilities.get_atom_map(
+        atom_map = get_atom_map(
             id_map=id_map,
             atoms=(
                 *self._atoms,
@@ -125,7 +125,7 @@ class GenericFunctionalGroup(_functional_group.FunctionalGroup):
             ),
         )
         clone = self.__class__.__new__(self.__class__)
-        _functional_group.FunctionalGroup.__init__(
+        FunctionalGroup.__init__(
             self=clone,
             atoms=tuple(
                 atom_map.get(atom.get_id(), atom)
@@ -151,7 +151,7 @@ class GenericFunctionalGroup(_functional_group.FunctionalGroup):
         )
         return clone
 
-    def get_bonders(self) -> abc.Iterable[_atoms.Atom]:
+    def get_bonders(self) -> abc.Iterable[Atom]:
         """
         Yield bonder atoms in the functional group.
 
@@ -190,7 +190,7 @@ class GenericFunctionalGroup(_functional_group.FunctionalGroup):
 
         yield from (a.get_id() for a in self._bonders)
 
-    def get_deleters(self) -> abc.Iterable[_atoms.Atom]:
+    def get_deleters(self) -> abc.Iterable[Atom]:
         """
         Yield the deleter atoms in the functional group.
 

--- a/src/stk/molecular/functional_groups/functional_groups/iodo.py
+++ b/src/stk/molecular/functional_groups/functional_groups/iodo.py
@@ -8,9 +8,9 @@ from __future__ import annotations
 
 import typing
 
-from . import utilities as _utilities
-from . import generic_functional_group as _generic_functional_group
-from ... import atoms as _atoms
+from .utilities import get_atom_map
+from .generic_functional_group import GenericFunctionalGroup
+from ...atoms import I, Atom
 
 
 __all__ = (
@@ -18,9 +18,7 @@ __all__ = (
 )
 
 
-class Iodo(
-    _generic_functional_group.GenericFunctionalGroup,
-):
+class Iodo(GenericFunctionalGroup):
     """
     Represents an iodo functional group.
 
@@ -32,11 +30,11 @@ class Iodo(
     def __init__(
         self,
         # I is not an ambiguous name.
-        iodine: _atoms.I,  # noqa
-        atom: _atoms.Atom,
-        bonders: tuple[_atoms.Atom, ...],
-        deleters: tuple[_atoms.Atom, ...],
-        placers: typing.Optional[tuple[_atoms.Atom, ...]] = None,
+        iodine: I,  # noqa
+        atom: Atom,
+        bonders: tuple[Atom, ...],
+        deleters: tuple[Atom, ...],
+        placers: typing.Optional[tuple[Atom, ...]] = None,
     ) -> None:
         """
         Initialize a :class:`.Iodo` instance.
@@ -61,7 +59,7 @@ class Iodo(
 
         """
 
-        _generic_functional_group.GenericFunctionalGroup.__init__(
+        GenericFunctionalGroup.__init__(
             self=self,
             atoms=(iodine, atom),
             bonders=bonders,
@@ -72,7 +70,7 @@ class Iodo(
         self._atom = atom
 
     # I is not an ambiguous name.
-    def get_iodine(self) -> _atoms.I:  # noqa
+    def get_iodine(self) -> I:  # noqa
         """
         Get the ``[iodine]`` atom.
 
@@ -84,7 +82,7 @@ class Iodo(
 
         return self._iodine
 
-    def get_atom(self) -> _atoms.Atom:
+    def get_atom(self) -> Atom:
         """
         Get the ``[atom]`` atom.
 
@@ -107,7 +105,7 @@ class Iodo(
         id_map: dict[int, int],
     ) -> Iodo:
 
-        atom_map = _utilities.get_atom_map(
+        atom_map = get_atom_map(
             id_map=id_map,
             atoms=(
                 *self._atoms,

--- a/src/stk/molecular/functional_groups/functional_groups/primary_amino.py
+++ b/src/stk/molecular/functional_groups/functional_groups/primary_amino.py
@@ -8,19 +8,16 @@ from __future__ import annotations
 
 import typing
 
-from . import utilities as _utilities
-from . import generic_functional_group as _generic_functional_group
-from ... import atoms as _atoms
-
+from .utilities import get_atom_map
+from .generic_functional_group import GenericFunctionalGroup
+from ...atoms import N, H, Atom
 
 __all__ = (
     'PrimaryAmino',
 )
 
 
-class PrimaryAmino(
-    _generic_functional_group.GenericFunctionalGroup,
-):
+class PrimaryAmino(GenericFunctionalGroup):
     """
     Represents a primary amino functional group.
 
@@ -31,13 +28,13 @@ class PrimaryAmino(
 
     def __init__(
         self,
-        nitrogen: _atoms.N,
-        hydrogen1: _atoms.H,
-        hydrogen2: _atoms.H,
-        atom: _atoms.Atom,
-        bonders: tuple[_atoms.Atom, ...],
-        deleters: tuple[_atoms.Atom, ...],
-        placers: typing.Optional[tuple[_atoms.Atom, ...]] = None,
+        nitrogen: N,
+        hydrogen1: H,
+        hydrogen2: H,
+        atom: Atom,
+        bonders: tuple[Atom, ...],
+        deleters: tuple[Atom, ...],
+        placers: typing.Optional[tuple[Atom, ...]] = None,
     ) -> None:
         """
         Initializes a :class:`.PrimaryAmino` instance.
@@ -68,7 +65,7 @@ class PrimaryAmino(
 
         """
 
-        _generic_functional_group.GenericFunctionalGroup.__init__(
+        GenericFunctionalGroup.__init__(
             self=self,
             atoms=(nitrogen, hydrogen1, hydrogen2, atom),
             bonders=bonders,
@@ -80,7 +77,7 @@ class PrimaryAmino(
         self._hydrogen2 = hydrogen2
         self._atom = atom
 
-    def get_nitrogen(self) -> _atoms.N:
+    def get_nitrogen(self) -> N:
         """
         Get the ``[nitrogen]`` atom.
 
@@ -92,7 +89,7 @@ class PrimaryAmino(
 
         return self._nitrogen
 
-    def get_hydrogen1(self) -> _atoms.H:
+    def get_hydrogen1(self) -> H:
         """
         Get the ``[hydrogen1]`` atom.
 
@@ -104,7 +101,7 @@ class PrimaryAmino(
 
         return self._hydrogen1
 
-    def get_hydrogen2(self) -> _atoms.H:
+    def get_hydrogen2(self) -> H:
         """
         Get the ``[hydrogen2]`` atom.
 
@@ -116,7 +113,7 @@ class PrimaryAmino(
 
         return self._hydrogen2
 
-    def get_atom(self) -> _atoms.Atom:
+    def get_atom(self) -> Atom:
         """
         Get the ``[atom]`` atom.
 
@@ -149,7 +146,7 @@ class PrimaryAmino(
         self,
         id_map: dict[int, int],
     ) -> PrimaryAmino:
-        atom_map = _utilities.get_atom_map(
+        atom_map = get_atom_map(
             id_map=id_map,
             atoms=(
                 *self._atoms,

--- a/src/stk/molecular/functional_groups/functional_groups/ring_amine.py
+++ b/src/stk/molecular/functional_groups/functional_groups/ring_amine.py
@@ -6,9 +6,9 @@ Ring Amine
 
 from __future__ import annotations
 
-from . import functional_group as _functional_group
-from . import utilities as _utilities
-from ... import atoms as _atoms
+from .utilities import get_atom_map
+from .functional_group import FunctionalGroup
+from ...atoms import N, H, C
 
 
 __all__ = (
@@ -16,7 +16,7 @@ __all__ = (
 )
 
 
-class RingAmine(_functional_group.FunctionalGroup):
+class RingAmine(FunctionalGroup):
     """
     Represents an amine bonded to a ring.
 
@@ -28,13 +28,13 @@ class RingAmine(_functional_group.FunctionalGroup):
 
     def __init__(
         self,
-        nitrogen: _atoms.N,
-        hydrogen1: _atoms.H,
-        hydrogen2: _atoms.H,
-        carbon1: _atoms.C,
-        carbon2: _atoms.C,
-        hydrogen3: _atoms.H,
-        carbon3: _atoms.C,
+        nitrogen: N,
+        hydrogen1: H,
+        hydrogen2: H,
+        carbon1: C,
+        carbon2: C,
+        hydrogen3: H,
+        carbon3: C,
     ) -> None:
         """
         Initializes a :class:`.RingAmine` instance.
@@ -64,7 +64,7 @@ class RingAmine(_functional_group.FunctionalGroup):
 
         """
 
-        _functional_group.FunctionalGroup.__init__(
+        FunctionalGroup.__init__(
             self=self,
             atoms=(
                 nitrogen,
@@ -86,7 +86,7 @@ class RingAmine(_functional_group.FunctionalGroup):
         self._carbon2 = carbon2
         self._carbon3 = carbon3
 
-    def get_nitrogen(self) -> _atoms.N:
+    def get_nitrogen(self) -> N:
         """
         Get the ``[nitrogen]`` atom.
 
@@ -98,7 +98,7 @@ class RingAmine(_functional_group.FunctionalGroup):
 
         return self._nitrogen
 
-    def get_hydrogen1(self) -> _atoms.H:
+    def get_hydrogen1(self) -> H:
         """
         Get the ``[hydrogen1]`` atom.
 
@@ -110,7 +110,7 @@ class RingAmine(_functional_group.FunctionalGroup):
 
         return self._hydrogen1
 
-    def get_hydrogen2(self) -> _atoms.H:
+    def get_hydrogen2(self) -> H:
         """
         Get the ``[hydrogen2]`` atom.
 
@@ -122,7 +122,7 @@ class RingAmine(_functional_group.FunctionalGroup):
 
         return self._hydrogen2
 
-    def get_carbon1(self) -> _atoms.C:
+    def get_carbon1(self) -> C:
         """
         Get the ``[carbon1]`` atom.
 
@@ -134,7 +134,7 @@ class RingAmine(_functional_group.FunctionalGroup):
 
         return self._carbon1
 
-    def get_carbon2(self) -> _atoms.C:
+    def get_carbon2(self) -> C:
         """
         Get the ``[carbon2]`` atom.
 
@@ -146,7 +146,7 @@ class RingAmine(_functional_group.FunctionalGroup):
 
         return self._carbon2
 
-    def get_hydrogen3(self) -> _atoms.H:
+    def get_hydrogen3(self) -> H:
         """
         Get the ``[hydrogen3]`` atom.
 
@@ -158,7 +158,7 @@ class RingAmine(_functional_group.FunctionalGroup):
 
         return self._hydrogen3
 
-    def get_carbon3(self) -> _atoms.C:
+    def get_carbon3(self) -> C:
         """
         Get the ``[carbon3]`` atom.
 
@@ -185,7 +185,7 @@ class RingAmine(_functional_group.FunctionalGroup):
         self,
         id_map: dict[int, int],
     ):
-        atom_map = _utilities.get_atom_map(
+        atom_map = get_atom_map(
             id_map=id_map,
             atoms=(
                 *self._atoms,

--- a/src/stk/molecular/functional_groups/functional_groups/secondary_amino.py
+++ b/src/stk/molecular/functional_groups/functional_groups/secondary_amino.py
@@ -8,9 +8,9 @@ from __future__ import annotations
 
 import typing
 
-from . import utilities as _utilities
-from . import generic_functional_group as _generic_functional_group
-from ... import atoms as _atoms
+from .utilities import get_atom_map
+from .generic_functional_group import GenericFunctionalGroup
+from ...atoms import N, H, Atom
 
 
 __all__ = (
@@ -18,9 +18,7 @@ __all__ = (
 )
 
 
-class SecondaryAmino(
-    _generic_functional_group.GenericFunctionalGroup,
-):
+class SecondaryAmino(GenericFunctionalGroup):
     """
     Represents a secondary amino functional group.
 
@@ -31,13 +29,13 @@ class SecondaryAmino(
 
     def __init__(
         self,
-        nitrogen: _atoms.N,
-        hydrogen: _atoms.H,
-        atom1: _atoms.Atom,
-        atom2: _atoms.Atom,
-        bonders: tuple[_atoms.Atom, ...],
-        deleters: tuple[_atoms.Atom, ...],
-        placers: typing.Optional[tuple[_atoms.Atom, ...]] = None,
+        nitrogen: N,
+        hydrogen: H,
+        atom1: Atom,
+        atom2: Atom,
+        bonders: tuple[Atom, ...],
+        deleters: tuple[Atom, ...],
+        placers: typing.Optional[tuple[Atom, ...]] = None,
     ) -> None:
         """
         Initialize a :class:`.SecondaryAmine` instance.
@@ -68,7 +66,7 @@ class SecondaryAmino(
 
         """
 
-        _generic_functional_group.GenericFunctionalGroup.__init__(
+        GenericFunctionalGroup.__init__(
             self=self,
             atoms=(nitrogen, hydrogen, atom1, atom2),
             bonders=bonders,
@@ -80,7 +78,7 @@ class SecondaryAmino(
         self._atom1 = atom1
         self._atom2 = atom2
 
-    def get_nitrogen(self) -> _atoms.N:
+    def get_nitrogen(self) -> N:
         """
         Get the ``[nitrogen]`` atom.
 
@@ -92,7 +90,7 @@ class SecondaryAmino(
 
         return self._nitrogen
 
-    def get_hydrogen(self) -> _atoms.H:
+    def get_hydrogen(self) -> H:
         """
         Get the ``[hydrogen]`` atom.
 
@@ -104,7 +102,7 @@ class SecondaryAmino(
 
         return self._hydrogen
 
-    def get_atom1(self) -> _atoms.Atom:
+    def get_atom1(self) -> Atom:
         """
         Get the ``[atom1]`` atom.
 
@@ -116,7 +114,7 @@ class SecondaryAmino(
 
         return self._atom1
 
-    def get_atom2(self) -> _atoms.Atom:
+    def get_atom2(self) -> Atom:
         """
         Get the ``[atom2]`` atom.
 
@@ -140,7 +138,7 @@ class SecondaryAmino(
         self,
         id_map: dict[int, int],
     ):
-        atom_map = _utilities.get_atom_map(
+        atom_map = get_atom_map(
             id_map=id_map,
             atoms=(
                 *self._atoms,

--- a/src/stk/molecular/functional_groups/functional_groups/single_atom.py
+++ b/src/stk/molecular/functional_groups/functional_groups/single_atom.py
@@ -6,9 +6,9 @@ Single Atom
 
 from __future__ import annotations
 
-from . import utilities as _utilities
-from . import generic_functional_group as _generic_functional_group
-from ... import atoms as _atoms
+from .utilities import get_atom_map
+from .generic_functional_group import GenericFunctionalGroup
+from ...atoms import Atom
 
 
 __all__ = (
@@ -16,9 +16,7 @@ __all__ = (
 )
 
 
-class SingleAtom(
-    _generic_functional_group.GenericFunctionalGroup,
-):
+class SingleAtom(GenericFunctionalGroup):
     """
     Represents an abstract single atom functional group.
 
@@ -27,7 +25,7 @@ class SingleAtom(
 
     """
 
-    def __init__(self, atom: _atoms.Atom) -> None:
+    def __init__(self, atom: Atom) -> None:
         """
         Initialize a :class:`.SingleAtom` instance.
 
@@ -38,7 +36,7 @@ class SingleAtom(
 
         """
 
-        _generic_functional_group.GenericFunctionalGroup.__init__(
+        GenericFunctionalGroup.__init__(
             self=self,
             atoms=(atom, ),
             bonders=(atom, ),
@@ -47,7 +45,7 @@ class SingleAtom(
         )
         self._atom = atom
 
-    def get_atom(self) -> _atoms.Atom:
+    def get_atom(self) -> Atom:
         """
         Get the atom that defines the functional group.
 
@@ -64,7 +62,7 @@ class SingleAtom(
         id_map: dict[int, int],
     ) -> SingleAtom:
 
-        atom_map = _utilities.get_atom_map(
+        atom_map = get_atom_map(
             id_map=id_map,
             atoms=(
                 *self._atoms,

--- a/src/stk/molecular/functional_groups/functional_groups/thioacid.py
+++ b/src/stk/molecular/functional_groups/functional_groups/thioacid.py
@@ -8,9 +8,9 @@ from __future__ import annotations
 
 import typing
 
-from . import utilities as _utilities
-from . import generic_functional_group as _generic_functional_group
-from ... import atoms as _atoms
+from .utilities import get_atom_map
+from .generic_functional_group import GenericFunctionalGroup
+from ...atoms import C, O, S, H, Atom
 
 
 __all__ = (
@@ -18,9 +18,7 @@ __all__ = (
 )
 
 
-class Thioacid(
-    _generic_functional_group.GenericFunctionalGroup,
-):
+class Thioacid(GenericFunctionalGroup):
     """
     Represents a thioacid functional group.
 
@@ -31,15 +29,15 @@ class Thioacid(
 
     def __init__(
         self,
-        carbon: _atoms.C,
+        carbon: C,
         # O is not an ambiguous name.
-        oxygen: _atoms.O,  # noqa
-        sulfur: _atoms.S,
-        hydrogen: _atoms.H,
-        atom: _atoms.Atom,
-        bonders: tuple[_atoms.Atom, ...],
-        deleters: tuple[_atoms.Atom, ...],
-        placers: typing.Optional[tuple[_atoms.Atom, ...]] = None,
+        oxygen: O,  # noqa
+        sulfur: S,
+        hydrogen: H,
+        atom: Atom,
+        bonders: tuple[Atom, ...],
+        deleters: tuple[Atom, ...],
+        placers: typing.Optional[tuple[Atom, ...]] = None,
     ) -> None:
         """
         Initialize a :class:`.Thioacid` functional group.
@@ -73,7 +71,7 @@ class Thioacid(
 
         """
 
-        _generic_functional_group.GenericFunctionalGroup.__init__(
+        GenericFunctionalGroup.__init__(
             self=self,
             atoms=(carbon, oxygen, sulfur, hydrogen, atom),
             bonders=bonders,
@@ -86,7 +84,7 @@ class Thioacid(
         self._hydrogen = hydrogen
         self._atom = atom
 
-    def get_carbon(self) -> _atoms.C:
+    def get_carbon(self) -> C:
         """
         Get the ``[carbon]`` atom.
 
@@ -99,7 +97,7 @@ class Thioacid(
         return self._carbon
 
     # O is not an ambiguous name.
-    def get_oxygen(self) -> _atoms.O:  # noqa
+    def get_oxygen(self) -> O:  # noqa
         """
         Get the ``[oxygen]`` atom.
 
@@ -111,7 +109,7 @@ class Thioacid(
 
         return self._oxygen
 
-    def get_sulfur(self) -> _atoms.S:
+    def get_sulfur(self) -> S:
         """
         Get the ``[sulfur]`` atom.
 
@@ -124,7 +122,7 @@ class Thioacid(
 
         return self._sulfur
 
-    def get_hydrogen(self) -> _atoms.H:
+    def get_hydrogen(self) -> H:
         """
         Get the ``[hydrogen]`` atom.
 
@@ -136,7 +134,7 @@ class Thioacid(
 
         return self._hydrogen
 
-    def get_atom(self) -> _atoms.Atom:
+    def get_atom(self) -> Atom:
         """
         Get the ``[atom]`` atom.
 
@@ -161,7 +159,7 @@ class Thioacid(
         self,
         id_map: dict[int, int],
     ) -> Thioacid:
-        atom_map = _utilities.get_atom_map(
+        atom_map = get_atom_map(
             id_map=id_map,
             atoms=(
                 *self._atoms,

--- a/src/stk/molecular/functional_groups/functional_groups/thiol.py
+++ b/src/stk/molecular/functional_groups/functional_groups/thiol.py
@@ -8,9 +8,9 @@ from __future__ import annotations
 
 import typing
 
-from . import utilities as _utilities
-from . import generic_functional_group as _generic_functional_group
-from ... import atoms as _atoms
+from .utilities import get_atom_map
+from .generic_functional_group import GenericFunctionalGroup
+from ...atoms import S, H, Atom
 
 
 __all__ = (
@@ -18,9 +18,7 @@ __all__ = (
 )
 
 
-class Thiol(
-    _generic_functional_group.GenericFunctionalGroup,
-):
+class Thiol(GenericFunctionalGroup):
     """
     Represents a thiol functional group.
 
@@ -32,12 +30,12 @@ class Thiol(
 
     def __init__(
         self,
-        sulfur: _atoms.S,
-        hydrogen: _atoms.H,
-        atom: _atoms.Atom,
-        bonders: tuple[_atoms.Atom, ...],
-        deleters: tuple[_atoms.Atom, ...],
-        placers: typing.Optional[tuple[_atoms.Atom, ...]] = None,
+        sulfur: S,
+        hydrogen: H,
+        atom: Atom,
+        bonders: tuple[Atom, ...],
+        deleters: tuple[Atom, ...],
+        placers: typing.Optional[tuple[Atom, ...]] = None,
     ) -> None:
         """
         Initialize a :class:`.Thiol` instance.
@@ -65,7 +63,7 @@ class Thiol(
 
         """
 
-        _generic_functional_group.GenericFunctionalGroup.__init__(
+        GenericFunctionalGroup.__init__(
             self=self,
             atoms=(sulfur, hydrogen, atom),
             bonders=bonders,
@@ -76,7 +74,7 @@ class Thiol(
         self._hydrogen = hydrogen
         self._atom = atom
 
-    def get_sulfur(self) -> _atoms.S:
+    def get_sulfur(self) -> S:
         """
         Get the ``[sulfur]`` atom.
 
@@ -88,7 +86,7 @@ class Thiol(
 
         return self._sulfur
 
-    def get_hydrogen(self) -> _atoms.H:
+    def get_hydrogen(self) -> H:
         """
         Get the ``[hydrogen]`` atom.
 
@@ -100,7 +98,7 @@ class Thiol(
 
         return self._hydrogen
 
-    def get_atom(self) -> _atoms.Atom:
+    def get_atom(self) -> Atom:
         """
         Get the ``[atom]`` atom.
 
@@ -124,7 +122,7 @@ class Thiol(
         id_map: dict[int, int],
     ) -> Thiol:
 
-        atom_map = _utilities.get_atom_map(
+        atom_map = get_atom_map(
             id_map=id_map,
             atoms=(
                 *self._atoms,

--- a/src/stk/molecular/functional_groups/functional_groups/utilities.py
+++ b/src/stk/molecular/functional_groups/functional_groups/utilities.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 
 from collections import abc
 
-from ... import atoms as _atoms
+from ...atoms import Atom
 
 
 __all__ = (
@@ -18,8 +18,8 @@ __all__ = (
 
 def get_atom_map(
     id_map: dict[int, int],
-    atoms: abc.Iterable[_atoms.Atom],
-) -> dict[int, _atoms.Atom]:
+    atoms: abc.Iterable[Atom],
+) -> dict[int, Atom]:
     """
     Get an atom map from an `id_map`.
 

--- a/src/stk/molecular/key_makers/inchi.py
+++ b/src/stk/molecular/key_makers/inchi.py
@@ -4,8 +4,8 @@ InChI
 
 """
 
-from . import molecule as _molecule
-from . import utilities as _utilities
+from .molecule import MoleculeKeyMaker
+from .utilities import get_inchi
 
 
 __all__ = (
@@ -13,7 +13,7 @@ __all__ = (
 )
 
 
-class Inchi(_molecule.MoleculeKeyMaker):
+class Inchi(MoleculeKeyMaker):
     """
     Used to get the InChI of molecules.
 
@@ -60,10 +60,10 @@ class Inchi(_molecule.MoleculeKeyMaker):
 
         """
 
-        _molecule.MoleculeKeyMaker.__init__(
+        MoleculeKeyMaker.__init__(
             self=self,
             key_name='InChI',
-            get_key=_utilities.get_inchi,
+            get_key=get_inchi,
         )
 
     def __str__(self) -> str:

--- a/src/stk/molecular/key_makers/inchi_key.py
+++ b/src/stk/molecular/key_makers/inchi_key.py
@@ -4,15 +4,15 @@ InChIKey
 
 """
 
-from . import molecule as _molecule
-from . import utilities as _utilities
+from .molecule import MoleculeKeyMaker
+from .utilities import get_inchi_key
 
 __all__ = (
     'InchiKey',
 )
 
 
-class InchiKey(_molecule.MoleculeKeyMaker):
+class InchiKey(MoleculeKeyMaker):
     """
     Used to get the InChIKey of molecules.
 
@@ -53,10 +53,10 @@ class InchiKey(_molecule.MoleculeKeyMaker):
 
         """
 
-        _molecule.MoleculeKeyMaker.__init__(
+        MoleculeKeyMaker.__init__(
             self=self,
             key_name='InChIKey',
-            get_key=_utilities.get_inchi_key,
+            get_key=get_inchi_key,
         )
 
     def __str__(self) -> str:

--- a/src/stk/molecular/key_makers/molecule.py
+++ b/src/stk/molecular/key_makers/molecule.py
@@ -14,7 +14,7 @@ Molecule Key Maker
 from __future__ import annotations
 
 from collections import abc
-from .. import molecule as _molecule
+from ..molecule import Molecule
 
 
 __all__ = (
@@ -80,7 +80,7 @@ class MoleculeKeyMaker:
     def __init__(
         self,
         key_name: str,
-        get_key: abc.Callable[[_molecule.Molecule], object],
+        get_key: abc.Callable[[Molecule], object],
     ) -> None:
         """
         Initialize a :class:`.MoleculeKeyMaker` instance.
@@ -112,7 +112,7 @@ class MoleculeKeyMaker:
 
         return self._key_name
 
-    def get_key(self, molecule: _molecule.Molecule) -> object:
+    def get_key(self, molecule: Molecule) -> object:
         """
         Get the key of `molecule`.
 

--- a/src/stk/molecular/key_makers/smiles.py
+++ b/src/stk/molecular/key_makers/smiles.py
@@ -4,8 +4,8 @@ SMILES
 
 """
 
-from . import molecule as _molecule
-from . import utilities as _utilities
+from .molecule import MoleculeKeyMaker
+from .utilities import get_smiles
 
 
 __all__ = (
@@ -13,7 +13,7 @@ __all__ = (
 )
 
 
-class Smiles(_molecule.MoleculeKeyMaker):
+class Smiles(MoleculeKeyMaker):
     """
     Used to get the SMILES of molecules.
 
@@ -48,10 +48,10 @@ class Smiles(_molecule.MoleculeKeyMaker):
 
         """
 
-        _molecule.MoleculeKeyMaker.__init__(
+        MoleculeKeyMaker.__init__(
             self=self,
             key_name='SMILES',
-            get_key=_utilities.get_smiles,
+            get_key=get_smiles,
         )
 
     def __str__(self) -> str:

--- a/src/stk/molecular/key_makers/utilities.py
+++ b/src/stk/molecular/key_makers/utilities.py
@@ -6,7 +6,7 @@ Key Maker Utilities
 
 import rdkit.Chem.AllChem as rdkit
 
-from .. import molecule as _molecule
+from .. molecule import Molecule
 
 __all__ = (
     'get_inchi',
@@ -15,7 +15,7 @@ __all__ = (
 )
 
 
-def get_inchi(molecule: _molecule.Molecule) -> str:
+def get_inchi(molecule: Molecule) -> str:
     """
     Get the InChI of `molecule`.
 
@@ -42,7 +42,7 @@ def get_inchi(molecule: _molecule.Molecule) -> str:
 
 
 def get_inchi_key(
-    molecule: _molecule.Molecule,
+    molecule: Molecule,
 ) -> str:
     """
     Get the InChIKey of `molecule`.
@@ -70,7 +70,7 @@ def get_inchi_key(
 
 
 def get_smiles(
-    molecule: _molecule.Molecule,
+    molecule: Molecule,
 ) -> str:
     """
     Get the RDKit canonical, isomeric SMILES of `molecule`.

--- a/src/stk/molecular/molecule/molecule.py
+++ b/src/stk/molecular/molecule/molecule.py
@@ -25,8 +25,8 @@ from stk import utilities as _utilities
 from stk.utilities import typing as _typing
 from .utilities import writers as _writers
 from .utilities import updaters as _updaters
-from .. import atoms as _atoms
-from .. import bonds as _bonds
+from ..atoms import Atom
+from ..bonds import Bond
 from .. import molecular_utilities as _molecular_utilities
 
 
@@ -111,8 +111,8 @@ class Molecule:
 
     def __init__(
         self,
-        atoms: tuple[_atoms.Atom, ...],
-        bonds: tuple[_bonds.Bond, ...],
+        atoms: tuple[Atom, ...],
+        bonds: tuple[Bond, ...],
         position_matrix: np.ndarray,
     ) -> None:
         """
@@ -469,7 +469,7 @@ class Molecule:
     def get_atoms(
         self,
         atom_ids: typing.Optional[_typing.OneOrMany[int]] = None,
-    ) -> abc.Iterable[_atoms.Atom]:
+    ) -> abc.Iterable[Atom]:
         """
         Yield the atoms in the molecule, ordered by id.
 
@@ -506,7 +506,7 @@ class Molecule:
 
         return len(self._atoms)
 
-    def get_bonds(self) -> abc.Iterable[_bonds.Bond]:
+    def get_bonds(self) -> abc.Iterable[Bond]:
         """
         Yield the bonds in the molecule.
 

--- a/src/stk/molecular/molecule/utilities/writers/mdl_mol.py
+++ b/src/stk/molecular/molecule/utilities/writers/mdl_mol.py
@@ -10,14 +10,14 @@ import pathlib
 import typing
 import numpy as np
 
-from .... import atoms as _atoms
-from .... import bonds as _bonds
+from ....atoms import Atom
+from ....bonds import Bond
 from stk.utilities import typing as _typing
 
 
 def write_mdl_mol_file(
-    atoms: tuple[_atoms.Atom, ...],
-    bonds: tuple[_bonds.Bond, ...],
+    atoms: tuple[Atom, ...],
+    bonds: tuple[Bond, ...],
     position_matrix: np.ndarray,
     path: typing.Union[pathlib.Path, str],
     atom_ids: typing.Optional[_typing.OneOrMany[int]],
@@ -59,8 +59,8 @@ def write_mdl_mol_file(
 
 
 def _to_mdl_mol_block(
-    atoms: tuple[_atoms.Atom, ...],
-    bonds: tuple[_bonds.Bond, ...],
+    atoms: tuple[Atom, ...],
+    bonds: tuple[Bond, ...],
     position_matrix: np.ndarray,
     atom_ids: typing.Optional[_typing.OneOrMany[int]],
 ) -> str:

--- a/src/stk/molecular/molecule/utilities/writers/pdb.py
+++ b/src/stk/molecular/molecule/utilities/writers/pdb.py
@@ -11,13 +11,13 @@ import typing
 import numpy as np
 
 from stk.utilities import typing as _typing
-from .... import atoms as _atoms
-from .... import bonds as _bonds
+from ....atoms import Atom
+from ....bonds import Bond
 
 
 def write_pdb_file(
-    atoms: tuple[_atoms.Atom, ...],
-    bonds: tuple[_bonds.Bond, ...],
+    atoms: tuple[Atom, ...],
+    bonds: tuple[Bond, ...],
     position_matrix: np.ndarray,
     path: typing.Union[pathlib.Path, str],
     atom_ids: typing.Optional[_typing.OneOrMany[int]],

--- a/src/stk/molecular/molecule/utilities/writers/xyz.py
+++ b/src/stk/molecular/molecule/utilities/writers/xyz.py
@@ -11,13 +11,13 @@ import pathlib
 import numpy as np
 
 from stk.utilities import typing as _typing
-from .... import atoms as _atoms
-from .... import bonds as _bonds
+from ....atoms import Atom
+from ....bonds import Bond
 
 
 def write_xyz_file(
-    atoms: tuple[_atoms.Atom, ...],
-    bonds: tuple[_bonds.Bond, ...],
+    atoms: tuple[Atom, ...],
+    bonds: tuple[Bond, ...],
     position_matrix: np.ndarray,
     path: typing.Union[pathlib.Path, str],
     atom_ids: typing.Optional[_typing.OneOrMany[int]],

--- a/src/stk/molecular/molecules/__init__.py
+++ b/src/stk/molecular/molecules/__init__.py
@@ -1,2 +1,0 @@
-from .building_block import *  # noqa
-from .constructed_molecule import *  # noqa

--- a/src/stk/molecular/molecules/building_block.py
+++ b/src/stk/molecular/molecules/building_block.py
@@ -16,10 +16,10 @@ import pathlib
 from collections import abc
 
 from stk.utilities import typing as _typing
-from .. import functional_groups as _functional_groups
-from .. import atoms as _atoms
-from .. import bonds as _bonds
-from .. import molecule as _molecule
+from ..functional_groups import FunctionalGroup, FunctionalGroupFactory
+from ..atoms import Atom
+from ..bonds import Bond
+from ..molecule import Molecule
 from ... import utilities as _utilities
 
 
@@ -44,8 +44,8 @@ class _InitFunc(typing.Protocol):
 
 
 _FunctionalGroups = abc.Iterable[typing.Union[
-    _functional_groups.FunctionalGroup,
-    _functional_groups.FunctionalGroupFactory,
+    FunctionalGroup,
+    FunctionalGroupFactory,
 ]]
 
 
@@ -155,7 +155,7 @@ class IMolecule(typing.Protocol):
         pass
 
 
-class BuildingBlock(_molecule.Molecule):
+class BuildingBlock(Molecule):
     """
     Represents a building block of a :class:`.ConstructedMolecule`.
 
@@ -280,7 +280,7 @@ class BuildingBlock(_molecule.Molecule):
     @classmethod
     def init_from_molecule(
         cls,
-        molecule: _molecule.Molecule,
+        molecule: Molecule,
         functional_groups: _FunctionalGroups = (),
         placer_ids: typing.Optional[abc.Iterable[int]] = None,
     ) -> BuildingBlock:
@@ -445,8 +445,8 @@ class BuildingBlock(_molecule.Molecule):
     @classmethod
     def init(
         cls,
-        atoms: tuple[_atoms.Atom, ...],
-        bonds: tuple[_bonds.Bond, ...],
+        atoms: tuple[Atom, ...],
+        bonds: tuple[Bond, ...],
         position_matrix: np.ndarray,
         functional_groups: _FunctionalGroups = (),
         placer_ids: typing.Optional[abc.Iterable[int]] = None,
@@ -499,7 +499,7 @@ class BuildingBlock(_molecule.Molecule):
         """
 
         building_block = cls.__new__(cls)
-        _molecule.Molecule.__init__(
+        Molecule.__init__(
             self=building_block,
             atoms=atoms,
             bonds=bonds,
@@ -699,7 +699,7 @@ class BuildingBlock(_molecule.Molecule):
         """
 
         atoms = tuple(
-            _atoms.Atom(
+            Atom(
                 id=a.GetIdx(),
                 atomic_number=a.GetAtomicNum(),
                 charge=a.GetFormalCharge(),
@@ -707,7 +707,7 @@ class BuildingBlock(_molecule.Molecule):
             for a in molecule.GetAtoms()
         )
         bonds = tuple(
-            _bonds.Bond(
+            Bond(
                 atom1=atoms[b.GetBeginAtomIdx()],
                 atom2=atoms[b.GetEndAtomIdx()],
                 order=(
@@ -719,7 +719,7 @@ class BuildingBlock(_molecule.Molecule):
         )
         position_matrix = molecule.GetConformer().GetPositions()
 
-        _molecule.Molecule.__init__(
+        Molecule.__init__(
             self=self,
             atoms=atoms,
             bonds=bonds,
@@ -739,8 +739,7 @@ class BuildingBlock(_molecule.Molecule):
     def _normalize_placer_ids(
         self,
         placer_ids: typing.Optional[abc.Iterable[int]],
-        functional_groups:
-            abc.Collection[_functional_groups.FunctionalGroup],
+        functional_groups: abc.Collection[FunctionalGroup],
     ) -> frozenset[int]:
         """
         Get the final *placer* ids.
@@ -784,8 +783,7 @@ class BuildingBlock(_molecule.Molecule):
 
     def _get_core_ids(
         self,
-        functional_groups:
-            abc.Iterable[_functional_groups.FunctionalGroup],
+        functional_groups: abc.Iterable[FunctionalGroup],
     ) -> abc.Iterable[int]:
         """
         Get the final *core* ids.
@@ -821,7 +819,7 @@ class BuildingBlock(_molecule.Molecule):
     def _extract_functional_groups(
         self,
         functional_groups: _FunctionalGroups,
-    ) -> abc.Iterable[_functional_groups.FunctionalGroup]:
+    ) -> abc.Iterable[FunctionalGroup]:
         """
         Yield functional groups.
 
@@ -847,7 +845,7 @@ class BuildingBlock(_molecule.Molecule):
         for functional_group in functional_groups:
             if isinstance(
                 functional_group,
-                _functional_groups.FunctionalGroup,
+                FunctionalGroup,
             ):
                 yield functional_group
             else:
@@ -856,8 +854,7 @@ class BuildingBlock(_molecule.Molecule):
 
     def _with_functional_groups(
         self: _T,
-        functional_groups:
-            abc.Iterable[_functional_groups.FunctionalGroup],
+        functional_groups: abc.Iterable[FunctionalGroup],
     ) -> _T:
         """
         Modify the molecule.
@@ -869,8 +866,7 @@ class BuildingBlock(_molecule.Molecule):
 
     def with_functional_groups(
         self,
-        functional_groups:
-            abc.Iterable[_functional_groups.FunctionalGroup],
+        functional_groups: abc.Iterable[FunctionalGroup],
     ) -> BuildingBlock:
         """
         Return a clone with specific functional groups.
@@ -927,7 +923,7 @@ class BuildingBlock(_molecule.Molecule):
     def get_functional_groups(
         self,
         fg_ids: typing.Optional[_typing.OneOrMany[int]] = None,
-    ) -> abc.Iterable[_functional_groups.FunctionalGroup]:
+    ) -> abc.Iterable[FunctionalGroup]:
         """
         Yield the functional groups, ordered by id.
 

--- a/src/stk/molecular/molecules/constructed_molecule.py
+++ b/src/stk/molecular/molecules/constructed_molecule.py
@@ -12,12 +12,12 @@ import numpy as np
 import rdkit.Chem.AllChem as rdkit
 from collections import abc
 
-from stk.utilities import typing as _typing
-from .. import molecule as _molecule
-from .. import atoms as _atoms
-from .. import bonds as _bonds
+from stk.utilities.typing import OneOrMany
+from ..molecule import Molecule
+from ..atoms import Atom, AtomInfo
+from ..bonds import Bond, BondInfo
 from .. import molecular_utilities as _utilities
-from .. import topology_graphs as _topology_graphs
+from ..topology_graphs import TopologyGraph, ConstructionResult
 
 
 _T = typing.TypeVar('_T', bound='ConstructedMolecule')
@@ -28,7 +28,7 @@ __all__ = (
 )
 
 
-class ConstructedMolecule(_molecule.Molecule):
+class ConstructedMolecule(Molecule):
     """
     Represents constructed molecules.
 
@@ -92,13 +92,13 @@ class ConstructedMolecule(_molecule.Molecule):
 
     """
 
-    _num_building_blocks: dict[_molecule.Molecule, int]
-    _atom_infos: tuple[_atoms.AtomInfo, ...]
-    _bond_infos: tuple[_bonds.BondInfo, ...]
+    _num_building_blocks: dict[Molecule, int]
+    _atom_infos: tuple[AtomInfo, ...]
+    _bond_infos: tuple[BondInfo, ...]
 
     def __init__(
         self,
-        topology_graph: _topology_graphs.TopologyGraph,
+        topology_graph: TopologyGraph,
     ) -> None:
         """
         Initialize a :class:`.ConstructedMolecule`.
@@ -118,12 +118,12 @@ class ConstructedMolecule(_molecule.Molecule):
     @classmethod
     def init(
         cls,
-        atoms: tuple[_atoms.Atom, ...],
-        bonds: tuple[_bonds.Bond, ...],
+        atoms: tuple[Atom, ...],
+        bonds: tuple[Bond, ...],
         position_matrix: np.ndarray,
-        atom_infos: tuple[_atoms.AtomInfo, ...],
-        bond_infos: tuple[_bonds.BondInfo, ...],
-        num_building_blocks: dict[_molecule.Molecule, int],
+        atom_infos: tuple[AtomInfo, ...],
+        bond_infos: tuple[BondInfo, ...],
+        num_building_blocks: dict[Molecule, int],
     ) -> ConstructedMolecule:
         """
         Initialize a :class:`.ConstructedMolecule` from its components.
@@ -156,7 +156,7 @@ class ConstructedMolecule(_molecule.Molecule):
         """
 
         molecule = cls.__new__(cls)
-        _molecule.Molecule.__init__(
+        Molecule.__init__(
             self=molecule,
             atoms=atoms,
             bonds=bonds,
@@ -170,7 +170,7 @@ class ConstructedMolecule(_molecule.Molecule):
     @classmethod
     def init_from_construction_result(
         cls,
-        construction_result: _topology_graphs.ConstructionResult,
+        construction_result: ConstructionResult,
     ) -> ConstructedMolecule:
         """
         Initialize a :class:`.ConstructedMolecule`.
@@ -195,7 +195,7 @@ class ConstructedMolecule(_molecule.Molecule):
     @staticmethod
     def _init_from_construction_result(
         obj: ConstructedMolecule,
-        construction_result: _topology_graphs.ConstructionResult,
+        construction_result: ConstructionResult,
     ) -> ConstructedMolecule:
         """
         Initialize a :class:`.ConstructedMolecule`.
@@ -217,7 +217,7 @@ class ConstructedMolecule(_molecule.Molecule):
 
         """
 
-        _molecule.Molecule.__init__(
+        Molecule.__init__(
             self=obj,
             atoms=construction_result.get_atoms(),
             bonds=construction_result.get_bonds(),
@@ -244,7 +244,7 @@ class ConstructedMolecule(_molecule.Molecule):
     def clone(self) -> ConstructedMolecule:
         return self._clone()
 
-    def get_building_blocks(self) -> abc.Iterable[_molecule.Molecule]:
+    def get_building_blocks(self) -> abc.Iterable[Molecule]:
         """
         Yield the building blocks of the constructed molecule.
 
@@ -264,7 +264,7 @@ class ConstructedMolecule(_molecule.Molecule):
 
     def get_num_building_block(
         self,
-        building_block: _molecule.Molecule,
+        building_block: Molecule,
     ) -> int:
         """
         Get the number of times `building_block` is present.
@@ -286,8 +286,8 @@ class ConstructedMolecule(_molecule.Molecule):
 
     def get_atom_infos(
         self,
-        atom_ids: typing.Optional[_typing.OneOrMany[int]] = None,
-    ) -> abc.Iterable[_atoms.AtomInfo]:
+        atom_ids: typing.Optional[OneOrMany[int]] = None,
+    ) -> abc.Iterable[AtomInfo]:
         """
         Yield data about atoms in the molecule.
 
@@ -312,7 +312,7 @@ class ConstructedMolecule(_molecule.Molecule):
         for atom_id in atom_ids:
             yield self._atom_infos[atom_id]
 
-    def get_bond_infos(self) -> abc.Iterable[_bonds.BondInfo]:
+    def get_bond_infos(self) -> abc.Iterable[BondInfo]:
         """
         Yield data about bonds in the molecule.
 
@@ -361,13 +361,13 @@ class ConstructedMolecule(_molecule.Molecule):
         }
         old_atom_infos = self._atom_infos
 
-        def get_atom_info(atom: _atoms.Atom) -> _atoms.AtomInfo:
+        def get_atom_info(atom: Atom) -> AtomInfo:
 
             old_atom_info = old_atom_infos[id_map[atom.get_id()]]
             old_building_block = old_atom_info.get_building_block()
 
             if old_building_block is None:
-                return _atoms.AtomInfo(
+                return AtomInfo(
                     atom=atom,
                     building_block_atom=None,
                     building_block=None,
@@ -392,7 +392,7 @@ class ConstructedMolecule(_molecule.Molecule):
                 )
             )
 
-            return _atoms.AtomInfo(
+            return AtomInfo(
                 atom=atom,
                 building_block_atom=canonical_building_block_atom,
                 building_block=canonical_building_block,
@@ -401,9 +401,9 @@ class ConstructedMolecule(_molecule.Molecule):
                 ),
             )
 
-        def get_bond_info(info: _bonds.BondInfo) -> _bonds.BondInfo:
+        def get_bond_info(info: BondInfo) -> BondInfo:
             building_block = info.get_building_block()
-            return _bonds.BondInfo(
+            return BondInfo(
                 bond=_utilities.sort_bond_atoms_by_id(
                     info.get_bond().with_atoms(atom_map)
                 ),
@@ -428,7 +428,7 @@ class ConstructedMolecule(_molecule.Molecule):
     def with_centroid(
         self,
         position: np.ndarray,
-        atom_ids: typing.Optional[_typing.OneOrMany[int]] = None,
+        atom_ids: typing.Optional[OneOrMany[int]] = None,
     ) -> ConstructedMolecule:
 
         return self.clone()._with_centroid(position, atom_ids)
@@ -499,7 +499,7 @@ class ConstructedMolecule(_molecule.Molecule):
     def write(
         self,
         path: typing.Union[pathlib.Path, str],
-        atom_ids: typing.Optional[_typing.OneOrMany[int]] = None,
+        atom_ids: typing.Optional[OneOrMany[int]] = None,
     ) -> ConstructedMolecule:
 
         return self._write(path, atom_ids)

--- a/src/stk/molecular/topology_graphs/host_guest/complex.py
+++ b/src/stk/molecular/topology_graphs/host_guest/complex.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 from typing import Optional
 from collections import abc
 
-from ...molecules import BuildingBlock
+from ...building_block import BuildingBlock
 from .vertices import HostVertex, GuestVertex
 from ..topology_graph import (
     TopologyGraph,

--- a/src/stk/molecular/topology_graphs/polymer/linear/linear.py
+++ b/src/stk/molecular/topology_graphs/polymer/linear/linear.py
@@ -10,7 +10,7 @@ from dataclasses import dataclass
 from collections import abc
 import numpy as np
 
-from ....molecules import BuildingBlock
+from ....building_block import BuildingBlock
 from .vertices import (
     HeadVertex,
     TailVertex,

--- a/src/stk/molecular/topology_graphs/topology_graph/construction_state/molecule_state/placements_summary/atom_batch.py
+++ b/src/stk/molecular/topology_graphs/topology_graph/construction_state/molecule_state/placements_summary/atom_batch.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 from collections import abc
 
 from ......atoms import Atom, AtomInfo
-from ......molecules import BuildingBlock
+from ......building_block import BuildingBlock
 
 
 class _AtomBatch:

--- a/src/stk/molecular/topology_graphs/topology_graph/construction_state/molecule_state/placements_summary/bond_batch.py
+++ b/src/stk/molecular/topology_graphs/topology_graph/construction_state/molecule_state/placements_summary/bond_batch.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 from collections import abc
 
 from ......bonds import Bond, BondInfo
-from ......molecules import BuildingBlock
+from ......building_block import BuildingBlock
 
 
 class _BondBatch:

--- a/src/stk/molecular/topology_graphs/topology_graph/construction_state/molecule_state/placements_summary/placements_summary.py
+++ b/src/stk/molecular/topology_graphs/topology_graph/construction_state/molecule_state/placements_summary/placements_summary.py
@@ -16,7 +16,7 @@ from .....topology_graph.topology_graph.implementations import (
 from ......functional_groups import FunctionalGroup
 from ......atoms import Atom, AtomInfo
 from ......bonds import Bond, BondInfo
-from ......molecules import BuildingBlock
+from ......building_block import BuildingBlock
 from .atom_batch import _AtomBatch
 from .bond_batch import _BondBatch
 


### PR DESCRIPTION
Stop using qualified imports. Qualified imports can mean that failed
imported are silently ignored in type hints.