### PR TITLE
Clear Aromatic Flags for `init_from_rdkit_mol`

### DIFF
--- a/src/stk/molecular/building_block.py
+++ b/src/stk/molecular/building_block.py
@@ -697,7 +697,8 @@ class BuildingBlock(Molecule):
                    *placer* ids.
 
         """
-
+        # Remove aromatic flags from atoms and bonds in the molecule.
+        rdkit.Kekulize(molecule, clearAromaticFlags=True)
         atoms = tuple(
             Atom(
                 id=a.GetIdx(),


### PR DESCRIPTION
Related Issues: #396 
Requested Reviewers: @lukasturcani, @andrewtarzia, @annabelbasford

This attempts to fix the issue when loading molecules with aromatic flags from RDKit. By removing aromatic flags, the aromatic bonds in the molecule (with bond order 1.5) are returned to alternating single and double bonds (orders 1 and 2 respectively). 

Risks are that if the Kekulization method fails for a molecule, an error will be thrown by RDKit - though I think this is highly unlikely to occur in general use. 

* `src/stk/molecular/building_block.py:.BuildingBlock._init_from_rdkit_mol()`: The Kekulization method was added to the first line of this function. 

Visually inspected molecule for changes. For an example, see the following code before and after the PR:

`benzene = rdkit.MolFromSmiles('c1ccccc1')`
`rdkit.EmbedMolecule(benzene)`
`stk.BuildingBlock.init_from_rdkit_mol(benzene).to_rdkit_mol()`
