### PR TITLE
init_from_rdkit_mol Docstring Edit

### DIFF
--- a/src/stk/molecular/molecules/building_block.py
+++ b/src/stk/molecular/molecules/building_block.py
@@ -493,7 +493,7 @@ class BuildingBlock(Molecule):
         Notes
         -----
         For :mod:`rdkit` molecules with non-integer bond orders,
-        such as 1.5, the molecule should be kekulized prior 
+        such as 1.5, the molecule should be kekulized prior to
         calling this method. Otherwise, all bond orders will be 
         set to an integer value in the building block.
 

--- a/src/stk/molecular/molecules/building_block.py
+++ b/src/stk/molecular/molecules/building_block.py
@@ -494,7 +494,8 @@ class BuildingBlock(Molecule):
         ----
         For rdkit molecules with aromatic rings of bond order 1.5,
         the molecule should be kekulized prior calling this method.
-        Otherwise, all bond orders will be set to 1 in the building block.
+        Otherwise, all bond orders will be set to 1 in the
+        building block.
 
         Parameters
         ----------

--- a/src/stk/molecular/molecules/building_block.py
+++ b/src/stk/molecular/molecules/building_block.py
@@ -492,10 +492,10 @@ class BuildingBlock(Molecule):
 
         Notes
         -----
-        For rdkit molecules with aromatic rings of bond order 1.5,
-        the molecule should be kekulized prior calling this method.
-        Otherwise, all bond orders will be set to 1 in the
-        building block.
+        For :mod:`rdkit` molecules with non-integer bond orders,
+        such as 1.5, the molecule should be kekulized prior 
+        calling this method. Otherwise, all bond orders will be 
+        set to an integer value in the building block.
 
         Parameters
         ----------

--- a/src/stk/molecular/molecules/building_block.py
+++ b/src/stk/molecular/molecules/building_block.py
@@ -490,8 +490,8 @@ class BuildingBlock(Molecule):
         """
         Initialize from an :mod:`rdkit` molecule.
 
-        Note
-        ----
+        Notes
+        -----
         For rdkit molecules with aromatic rings of bond order 1.5,
         the molecule should be kekulized prior calling this method.
         Otherwise, all bond orders will be set to 1 in the

--- a/src/stk/molecular/molecules/building_block.py
+++ b/src/stk/molecular/molecules/building_block.py
@@ -470,7 +470,7 @@ class BuildingBlock(Molecule):
             )
         # This remake needs to be here because molecules loaded
         # with rdkit often have issues, because rdkit tries to do
-        # bits of structural analysis like stereocenters. remake
+        # bits of structural analysis like stereocenters. Remake
         # gets rid of all this problematic metadata.
         molecule = remake(cls._init_funcs[extension](path))
 
@@ -489,6 +489,12 @@ class BuildingBlock(Molecule):
     ):
         """
         Initialize from an :mod:`rdkit` molecule.
+
+        Note
+        ----
+        For rdkit molecules with aromatic rings of bond order 1.5,
+        the molecule should be kekulized prior calling this method.
+        Otherwise, all bond orders will be set to 1 in the building block.
 
         Parameters
         ----------

--- a/src/stk/molecular/molecules/building_block.py
+++ b/src/stk/molecular/molecules/building_block.py
@@ -494,7 +494,7 @@ class BuildingBlock(Molecule):
         -----
         For :mod:`rdkit` molecules with non-integer bond orders,
         such as 1.5, the molecule should be kekulized prior to
-        calling this method. Otherwise, all bond orders will be 
+        calling this method. Otherwise, all bond orders will be
         set to an integer value in the building block.
 
         Parameters


### PR DESCRIPTION
Related Issues: #396

Requested Reviewers: @lukasturcani 

Added additional notes section in the docstring to explain that users should kekulize their molecule prior to calling the `init_form_rdkit_mol` method. It also explains the consequences of not doing so (bond orders changed to 1).
Also fixed a capital letter. 

As this does not change any code, there will be no issues with this code change.
