### PR TITLE
Add a Makefile for quickly running all checks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,14 @@
+.DEFAULT_GOAL := help
+
+.PHONY: help
+help: ## Show this help
+	@awk 'BEGIN {FS = ":.*?## "} /^[a-zA-Z_-]+:.*?## / {printf "\033[1m%-15s\033[0m %s\n", $$1, $$2}' $(MAKEFILE_LIST)
+
+.PHONY: check
+check: ## Check the source code
+	-./docs/remake_modules.bash
+	-make -C docs doctest
+	-pytest
+	-isort .
+	-mypy src
+	-flake8 src tests benchmarks

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,7 @@
-from setuptools import find_packages, setup
 import re
 from os.path import join
+
+from setuptools import find_packages, setup
 
 
 def get_version():


### PR DESCRIPTION
I've added a Makefile which can be used with `make check` so that
all the tests, and linting checks are performed in one go, rather
than the developer having to call them individually. This is purely
to help the local development workflow, it is not to be used with CI.
