### PR TITLE
Add deprecation notice for `pdb` reading

### DIFF
--- a/src/stk/molecular/molecules/building_block.py
+++ b/src/stk/molecular/molecules/building_block.py
@@ -14,6 +14,7 @@ from functools import partial
 
 import numpy as np
 import rdkit.Chem.AllChem as rdkit
+import warnings
 import vabene
 
 from ...utilities import OneOrMany, flatten, remake
@@ -437,7 +438,6 @@ class BuildingBlock(Molecule):
                 types are:
 
                     #. ``.mol``, ``.sdf`` - MDL V3000 MOL file
-                    #. ``.pdb`` - PDB file
 
             functional_groups:
                 An :class:`iterable` of :class:`.FunctionalGroup` or
@@ -483,6 +483,15 @@ class BuildingBlock(Molecule):
         """
 
         _, extension = os.path.splitext(path)
+
+        if extension == '.pdb':
+            warnings.warn(
+                'Loading from .pdb files is deprecated and will be '
+                'removed from stk versions released after 1st Nov '
+                '2022. Please use .mol files for loading molecules '
+                'instead.',
+                category=FutureWarning,
+            )
 
         if extension not in cls._init_funcs:
             raise ValueError(

--- a/src/stk/molecular/molecules/building_block.py
+++ b/src/stk/molecular/molecules/building_block.py
@@ -9,12 +9,12 @@ from __future__ import annotations
 import logging
 import os
 import typing
+import warnings
 from collections.abc import Collection
 from functools import partial
 
 import numpy as np
 import rdkit.Chem.AllChem as rdkit
-import warnings
 import vabene
 
 from ...utilities import OneOrMany, flatten, remake


### PR DESCRIPTION
Related Issues: #446 
Requested Reviewers: @andrewtarzia 
*Note for Reviewers: If you accept the review request add a :+1: to this post*

Removes the note that users can load `pdb` files from the docstring of 
`init_from_file`, in order to stop new users from using these files for loading
molecules. Loading will still work for now, but users will receive a `FutureWarning`
telling them that they should switch to `.mol` files.

The reason this deprecation is necessary is that `pdb` files do not encode bond
orders and the loaded building blocks may therefore have wrong or unexpected
connectivity. By explicitly not supporting this file type we make sure our users
carefully consider the bonding of their molecules and avoid surprises.

