### PR TITLE
Add type hints

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -33,3 +33,6 @@ ignore_missing_imports = True
 
 [mypy]
 show_error_codes = True
+no_implicit_optional = True
+warn_no_return = True
+strict_optional = True

--- a/src/stk/molecular/key_makers/inchi.py
+++ b/src/stk/molecular/key_makers/inchi.py
@@ -6,6 +6,7 @@ InChI
 
 from __future__ import annotations
 
+from ..molecules import Molecule
 from .molecule import MoleculeKeyMaker
 from .utilities import get_inchi
 
@@ -57,7 +58,13 @@ class Inchi(MoleculeKeyMaker):
 
         """
 
-        super().__init__('InChI', get_inchi)
+        pass
+
+    def get_key_name(self) -> str:
+        return 'InChI'
+
+    def get_key(self, molecule: Molecule) -> str:
+        return get_inchi(molecule)
 
     def __str__(self) -> str:
         return repr(self)

--- a/src/stk/molecular/key_makers/inchi_key.py
+++ b/src/stk/molecular/key_makers/inchi_key.py
@@ -6,6 +6,7 @@ InChIKey
 
 from __future__ import annotations
 
+from ..molecules import Molecule
 from .molecule import MoleculeKeyMaker
 from .utilities import get_inchi_key
 
@@ -51,7 +52,13 @@ class InchiKey(MoleculeKeyMaker):
 
         """
 
-        super().__init__('InChIKey', get_inchi_key)
+        pass
+
+    def get_key_name(self) -> str:
+        return 'InChIKey'
+
+    def get_key(self, molecule: Molecule) -> str:
+        return get_inchi_key(molecule)
 
     def __str__(self) -> str:
         return repr(self)

--- a/src/stk/molecular/key_makers/smiles.py
+++ b/src/stk/molecular/key_makers/smiles.py
@@ -6,6 +6,7 @@ SMILES
 
 from __future__ import annotations
 
+from ..molecules import Molecule
 from .molecule import MoleculeKeyMaker
 from .utilities import get_smiles
 
@@ -45,7 +46,13 @@ class Smiles(MoleculeKeyMaker):
 
         """
 
-        super().__init__('SMILES', get_smiles)
+        pass
+
+    def get_key_name(self) -> str:
+        return 'SMILES'
+
+    def get_key(self, molecule: Molecule) -> str:
+        return get_smiles(molecule)
 
     def __str__(self) -> str:
         return repr(self)

--- a/src/stk/molecular/key_makers/utilities.py
+++ b/src/stk/molecular/key_makers/utilities.py
@@ -13,7 +13,7 @@ from ..molecules import Molecule
 
 def get_inchi(
     molecule: Molecule,
-):
+) -> str:
     """
     Get the InChI of `molecule`.
 


### PR DESCRIPTION
Requested Reviewers: @andrewtarzia
*Note for Reviewers: If you accept the review request add a :+1: to this post*

Refactored the key makers to explicitly provide type hints rather
than rely on the default implementation. It is sometimes useful to
be able to rely on the more specific type of the key.