### PR TITLE
Implement initialization with pathlib.Path

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ src/stk/_version.py
 **/__pycache__/
 
 **/.cache
+**/.mypy_cache
 *.ipynb_checkpoints
 **/.vscode
 

--- a/.gitignore
+++ b/.gitignore
@@ -6,7 +6,7 @@ src/stk/_version.py
 **/__pycache__/
 
 **/.cache
-**/.mypy_cache
+.mypy_cache
 *.ipynb_checkpoints
 **/.vscode
 

--- a/src/stk/molecular/writers/mdl_mol.py
+++ b/src/stk/molecular/writers/mdl_mol.py
@@ -6,8 +6,8 @@ Mol Writer
 
 from __future__ import annotations
 
-import typing
 import pathlib
+import typing
 
 from ...utilities import OneOrMany
 from ..molecules import Molecule

--- a/src/stk/molecular/writers/mdl_mol.py
+++ b/src/stk/molecular/writers/mdl_mol.py
@@ -7,6 +7,7 @@ Mol Writer
 from __future__ import annotations
 
 import typing
+import pathlib
 
 from ...utilities import OneOrMany
 from ..molecules import Molecule
@@ -132,7 +133,7 @@ class MolWriter:
     def write(
         self,
         molecule: Molecule,
-        path: str,
+        path: pathlib.Path | str,
         atom_ids: typing.Optional[OneOrMany[int]] = None,
     ) -> None:
         """

--- a/src/stk/molecular/writers/pdb.py
+++ b/src/stk/molecular/writers/pdb.py
@@ -6,8 +6,8 @@ PDB Writer
 
 from __future__ import annotations
 
-import typing
 import pathlib
+import typing
 
 from ...utilities import OneOrMany
 from ..molecules import Molecule

--- a/src/stk/molecular/writers/pdb.py
+++ b/src/stk/molecular/writers/pdb.py
@@ -7,6 +7,7 @@ PDB Writer
 from __future__ import annotations
 
 import typing
+import pathlib
 
 from ...utilities import OneOrMany
 from ..molecules import Molecule
@@ -177,7 +178,7 @@ class PdbWriter:
     def write(
         self,
         molecule: Molecule,
-        path: str,
+        path: pathlib.Path | str,
         atom_ids: typing.Optional[OneOrMany[int]] = None,
         periodic_info: typing.Optional[PeriodicInfo] = None,
     ) -> None:

--- a/src/stk/molecular/writers/xyz.py
+++ b/src/stk/molecular/writers/xyz.py
@@ -6,8 +6,8 @@ XYZ Writer
 
 from __future__ import annotations
 
-import typing
 import pathlib
+import typing
 
 from ...utilities import OneOrMany
 from ..molecules import Molecule

--- a/src/stk/molecular/writers/xyz.py
+++ b/src/stk/molecular/writers/xyz.py
@@ -7,6 +7,7 @@ XYZ Writer
 from __future__ import annotations
 
 import typing
+import pathlib
 
 from ...utilities import OneOrMany
 from ..molecules import Molecule
@@ -96,7 +97,7 @@ class XyzWriter:
     def write(
         self,
         molecule: Molecule,
-        path: str,
+        path: pathlib.Path | str,
         atom_ids: typing.Optional[OneOrMany[int]] = None,
     ) -> None:
         """


### PR DESCRIPTION
``xyz``, ``pdb``, and ``mdl_mol`` can now be initialized using pathlib.Paths.

Updated the type hints to allow pathlibs and imported pathlib
