### PR TITLE
Update generic structures for topology graphs using single atom representations.

### DIFF
--- a/src/stk/_internal/topology_graphs/cage/four_plus_six.py
+++ b/src/stk/_internal/topology_graphs/cage/four_plus_six.py
@@ -16,23 +16,36 @@ class FourPlusSix(Cage):
     """
     Represents a cage topology graph.
 
-    Unoptimized construction
+    Vertex connectivities:
 
     .. moldoc::
 
         import moldoc.molecule as molecule
         import stk
 
-        bb1 = stk.BuildingBlock(
-            smiles='NC1CCCCC1N',
-            functional_groups=[stk.PrimaryAminoFactory()],
+        three_c_bb = stk.BuildingBlock(
+            smiles="[Br][C]([Br])[Br]",
+            position_matrix=[
+                [-2, 0, -1],
+                [0, 0, 1],
+                [0, -2, -1],
+                [2, 0, 1],
+            ],
+            functional_groups=(stk.BromoFactory(placers=(0, 1)),),
         )
-        bb2 = stk.BuildingBlock(
-            smiles='O=Cc1cc(C=O)cc(C=O)c1',
-            functional_groups=[stk.AldehydeFactory()],
+
+        two_c_bb = stk.BuildingBlock(
+            smiles="[Br][N][Br]",
+            position_matrix=[
+                [-2, 0, -1],
+                [0, 0, 1],
+                [0, -2, -1],
+            ],
+            functional_groups=(stk.BromoFactory(placers=(0, 1)),),
         )
+
         cage = stk.ConstructedMolecule(
-            topology_graph=stk.cage.FourPlusSix((bb1, bb2)),
+            topology_graph=stk.cage.FourPlusSix((three_c_bb, two_c_bb)),
         )
 
         moldoc_display_molecule = molecule.Molecule(
@@ -54,52 +67,13 @@ class FourPlusSix(Cage):
             ),
         )
 
-    :class:`.MCHammer` optimized construction
-
-    .. moldoc::
-
-        import moldoc.molecule as molecule
-        import stk
-
-        bb1 = stk.BuildingBlock(
-            smiles='NC1CCCCC1N',
-            functional_groups=[stk.PrimaryAminoFactory()],
-        )
-        bb2 = stk.BuildingBlock(
-            smiles='O=Cc1cc(C=O)cc(C=O)c1',
-            functional_groups=[stk.AldehydeFactory()],
-        )
-        cage = stk.ConstructedMolecule(
-            topology_graph=stk.cage.FourPlusSix(
-                building_blocks=(bb1, bb2),
-                optimizer=stk.MCHammer(),
-            ),
-        )
-
-        moldoc_display_molecule = molecule.Molecule(
-            atoms=(
-                molecule.Atom(
-                    atomic_number=atom.get_atomic_number(),
-                    position=position,
-                ) for atom, position in zip(
-                    cage.get_atoms(),
-                    cage.get_position_matrix(),
-                )
-            ),
-            bonds=(
-                molecule.Bond(
-                    atom1_id=bond.get_atom1().get_id(),
-                    atom2_id=bond.get_atom2().get_id(),
-                    order=bond.get_order(),
-                ) for bond in cage.get_bonds()
-            ),
-        )
-
-    Nonlinear building blocks with three functional groups are
+    Nonlinear building blocks (COLOUR1) with three functional groups are
     required for this topology.
 
-    Linear building blocks with two functional groups are required for
+    Linear building blocks (COLOUR2) with two functional groups are required for
     this topology.
+    
+    :class:`.MCHammer` optimization is recommended for construction.
 
     When using a :class:`dict` for the `building_blocks` parameter,
     as in :ref:`cage-topology-graph-examples`:
@@ -107,8 +81,8 @@ class FourPlusSix(Cage):
     :class:`.BuildingBlock`, with the following number of functional
     groups, needs to be assigned to each of the following vertex ids:
 
-        | 3-functional groups: 0 to 3
-        | 2-functional groups: 4 to 9
+        | 3-functional groups (COLOUR1): 0 to 3
+        | 2-functional groups (COLOUR2): 4 to 9
 
     See :class:`.Cage` for more details and examples.
 

--- a/src/stk/_internal/topology_graphs/cage/four_plus_six.py
+++ b/src/stk/_internal/topology_graphs/cage/four_plus_six.py
@@ -67,12 +67,12 @@ class FourPlusSix(Cage):
             ),
         )
 
-    Nonlinear building blocks (COLOUR1) with three functional groups are
-    required for this topology.
+    Nonlinear building blocks (COLOUR1) with three functional groups
+    are required for this topology.
 
-    Linear building blocks (COLOUR2) with two functional groups are required for
-    this topology.
-    
+    Linear building blocks (COLOUR2) with two functional groups
+    are required for this topology.
+
     :class:`.MCHammer` optimization is recommended for construction.
 
     When using a :class:`dict` for the `building_blocks` parameter,

--- a/src/stk/_internal/topology_graphs/cage/m12l24.py
+++ b/src/stk/_internal/topology_graphs/cage/m12l24.py
@@ -47,35 +47,15 @@ class M12L24(Cage):
                 building_blocks=(bb1, bb2),
             ),
         )
-        rgb1 = [192, 87, 161]
-        rgb2 = [97, 201, 217]
-        points = cage.get_num_atoms()
-        colour_list = [
-            [
-                (rgb1[0]-rgb2[0])*i,
-                (rgb1[1]-rgb2[1])*i,
-                (rgb1[2]-rgb2[2])*i,
-            ]
-            for i in range(points)
-        ]
 
         moldoc_display_molecule = molecule.Molecule(
             atoms=(
                 molecule.Atom(
                     atomic_number=atom.get_atomic_number(),
                     position=position,
-                    config=molecule.AtomConfig(
-                        color=molecule.Color(
-                            red=col[0],
-                            green=col[1],
-                            blue=col[2],
-                        ),
-                        size=2.0,
-                    )
-                ) for atom, position, col in zip(
+                ) for atom, position in zip(
                     cage.get_atoms(),
                     cage.get_position_matrix(),
-                    colour_list,
                 )
             ),
             bonds=(

--- a/src/stk/_internal/topology_graphs/cage/m12l24.py
+++ b/src/stk/_internal/topology_graphs/cage/m12l24.py
@@ -47,15 +47,35 @@ class M12L24(Cage):
                 building_blocks=(bb1, bb2),
             ),
         )
+        rgb1 = [192, 87, 161]
+        rgb2 = [97, 201, 217]
+        points = cage.get_num_atoms()
+        colour_list = [
+            [
+                (rgb1[0]-rgb2[0])*i,
+                (rgb1[1]-rgb2[1])*i,
+                (rgb1[2]-rgb2[2])*i,
+            ]
+            for i in range(points)
+        ]
 
         moldoc_display_molecule = molecule.Molecule(
             atoms=(
                 molecule.Atom(
                     atomic_number=atom.get_atomic_number(),
                     position=position,
-                ) for atom, position in zip(
+                    config=molecule.AtomConfig(
+                        color=molecule.Color(
+                            red=col[0],
+                            green=col[1],
+                            blue=col[2],
+                        ),
+                        size=2.0,
+                    )
+                ) for atom, position, col in zip(
                     cage.get_atoms(),
                     cage.get_position_matrix(),
+                    colour_list,
                 )
             ),
             bonds=(

--- a/src/stk/_internal/topology_graphs/cage/m24l48.py
+++ b/src/stk/_internal/topology_graphs/cage/m24l48.py
@@ -51,9 +51,9 @@ class M24L48(Cage):
         points = cage.get_num_atoms()
         colour_list = [
             [
-                (rgb1[0]-rgb2[0])*i,
-                (rgb1[1]-rgb2[1])*i,
-                (rgb1[2]-rgb2[2])*i,
+                rgb1[0] + (rgb1[0]-rgb2[0])*i,
+                rgb1[1] + (rgb1[1]-rgb2[1])*i,
+                rgb1[2] + (rgb1[2]-rgb2[2])*i,
             ]
             for i in range(points)
         ]

--- a/src/stk/_internal/topology_graphs/cage/m24l48.py
+++ b/src/stk/_internal/topology_graphs/cage/m24l48.py
@@ -18,7 +18,7 @@ class M24L48(Cage):
 
         import moldoc.molecule as molecule
         import stk
-        
+
         four_c_bb = stk.BuildingBlock(
             smiles="[Br][C]([Br])([Br])[Br]",
             position_matrix=[
@@ -70,11 +70,11 @@ class M24L48(Cage):
             ),
         )
 
-    Metal building blocks (COLOUR1) with four functional groups are
-    required for this topology.
+    Metal building blocks (COLOUR1) with four functional groups
+    are required for this topology.
 
-    Ligand building blocks (COLOUR2) with two functional groups are required for
-    this topology.
+    Ligand building blocks (COLOUR2) with two functional groups
+    are required for this topology.
 
     :class:`.MCHammer` optimization is recommended for construction.
 
@@ -84,7 +84,7 @@ class M24L48(Cage):
     :class:`.BuildingBlock`, with the following number of functional
     groups, needs to be assigned to each of the following vertex ids:
 
-        | 4-functional groups (u'\u25FC', COLOUR1): 0 to 23
+        | 4-functional groups (\u25FC, COLOUR1): 0 to 23
         | 2-functional groups (u'\u25FC', COLOUR2): 24 to 71
 
     See :class:`.Cage` for more details and examples.

--- a/src/stk/_internal/topology_graphs/cage/m24l48.py
+++ b/src/stk/_internal/topology_graphs/cage/m24l48.py
@@ -84,8 +84,8 @@ class M24L48(Cage):
     :class:`.BuildingBlock`, with the following number of functional
     groups, needs to be assigned to each of the following vertex ids:
 
-        | 4-functional groups (U+25FC, COLOUR1): 0 to 23
-        | 2-functional groups (U+25FC, COLOUR2): 24 to 71
+        | 4-functional groups (u'\u25FC', COLOUR1): 0 to 23
+        | 2-functional groups (u'\u25FC', COLOUR2): 24 to 71
 
     See :class:`.Cage` for more details and examples.
 

--- a/src/stk/_internal/topology_graphs/cage/m24l48.py
+++ b/src/stk/_internal/topology_graphs/cage/m24l48.py
@@ -18,33 +18,32 @@ class M24L48(Cage):
 
         import moldoc.molecule as molecule
         import stk
-
-        bb1 = stk.BuildingBlock(
-            smiles='[Pd+2]',
-            functional_groups=(
-                stk.SingleAtom(stk.Pd(0, charge=2))
-                for i in range(4)
-            ),
-            position_matrix=[[0, 0, 0]],
+        
+        four_c_bb = stk.BuildingBlock(
+            smiles="[Br][C]([Br])([Br])[Br]",
+            position_matrix=[
+                [-2, 0, -1],
+                [0, 0, 1],
+                [0, -2, -1],
+                [2, 0, 1],
+                [0, 2, 1],
+            ],
+            functional_groups=(stk.BromoFactory(placers=(0, 1)),),
         )
 
-        bb2 = stk.BuildingBlock(
-            smiles=(
-                'C1=NC=CC(C2=CC=CC(C3=C'
-                'C=NC=C3)=C2)=C1'
-            ),
-            functional_groups=[
-                stk.SmartsFunctionalGroupFactory(
-                    smarts='[#6]~[#7X2]~[#6]',
-                    bonders=(1, ),
-                    deleters=(),
-                ),
+        two_c_bb = stk.BuildingBlock(
+            smiles="[Br][N][Br]",
+            position_matrix=[
+                [-2, 0, -1],
+                [0, 0, 1],
+                [0, -2, -1],
             ],
+            functional_groups=(stk.BromoFactory(placers=(0, 1)),),
         )
 
         cage = stk.ConstructedMolecule(
             topology_graph=stk.cage.M24L48(
-                building_blocks=(bb1, bb2),
+                building_blocks=(four_c_bb, two_c_bb),
             ),
         )
 
@@ -71,11 +70,13 @@ class M24L48(Cage):
             ),
         )
 
-    Metal building blocks with four functional groups are
+    Metal building blocks (COLOUR1) with four functional groups are
     required for this topology.
 
-    Ligand building blocks with two functional groups are required for
+    Ligand building blocks (COLOUR2) with two functional groups are required for
     this topology.
+
+    :class:`.MCHammer` optimization is recommended for construction.
 
     When using a :class:`dict` for the `building_blocks` parameter,
     as in :ref:`cage-topology-graph-examples`:
@@ -83,8 +84,8 @@ class M24L48(Cage):
     :class:`.BuildingBlock`, with the following number of functional
     groups, needs to be assigned to each of the following vertex ids:
 
-        | 4-functional groups: 0 to 23
-        | 2-functional groups: 24 to 71
+        | 4-functional groups (U+25FC, COLOUR1): 0 to 23
+        | 2-functional groups (U+25FC, COLOUR2): 24 to 71
 
     See :class:`.Cage` for more details and examples.
 

--- a/src/stk/_internal/topology_graphs/cage/m24l48.py
+++ b/src/stk/_internal/topology_graphs/cage/m24l48.py
@@ -46,15 +46,35 @@ class M24L48(Cage):
                 building_blocks=(four_c_bb, two_c_bb),
             ),
         )
+        rgb1 = [192, 87, 161]
+        rgb2 = [97, 201, 217]
+        points = cage.get_num_atoms()
+        colour_list = [
+            [
+                (rgb1[0]-rgb2[0])*i,
+                (rgb1[1]-rgb2[1])*i,
+                (rgb1[2]-rgb2[2])*i,
+            ]
+            for i in range(points)
+        ]
 
         moldoc_display_molecule = molecule.Molecule(
             atoms=(
                 molecule.Atom(
                     atomic_number=atom.get_atomic_number(),
                     position=position,
-                ) for atom, position in zip(
+                    config=molecule.AtomConfig(
+                        color=molecule.Color(
+                            red=col[0],
+                            green=col[1],
+                            blue=col[2],
+                        ),
+                        size=2.0,
+                    )
+                ) for atom, position, col in zip(
                     cage.get_atoms(),
                     cage.get_position_matrix(),
+                    colour_list,
                 )
             ),
             bonds=(

--- a/src/stk/_internal/topology_graphs/cage/m24l48.py
+++ b/src/stk/_internal/topology_graphs/cage/m24l48.py
@@ -51,9 +51,9 @@ class M24L48(Cage):
         points = cage.get_num_atoms()
         colour_list = [
             [
-                rgb1[0] + ((rgb2[0]-rgb1[0])/points)*i,
-                rgb1[1] + ((rgb2[1]-rgb1[1])/points)*i,
-                rgb1[2] + ((rgb2[2]-rgb1[2])/points)*i,
+                int(rgb1[0] + ((rgb2[0]-rgb1[0])/points)*i),
+                int(rgb1[1] + ((rgb2[1]-rgb1[1])/points)*i),
+                int(rgb1[2] + ((rgb2[2]-rgb1[2])/points)*i),
             ]
             for i in range(points)
         ]

--- a/src/stk/_internal/topology_graphs/cage/m24l48.py
+++ b/src/stk/_internal/topology_graphs/cage/m24l48.py
@@ -51,9 +51,9 @@ class M24L48(Cage):
         points = cage.get_num_atoms()
         colour_list = [
             [
-                rgb1[0] + (rgb1[0]-rgb2[0])*i,
-                rgb1[1] + (rgb1[1]-rgb2[1])*i,
-                rgb1[2] + (rgb1[2]-rgb2[2])*i,
+                rgb1[0] + ((rgb2[0]-rgb1[0])/points)*i,
+                rgb1[1] + ((rgb2[1]-rgb1[1])/points)*i,
+                rgb1[2] + ((rgb2[2]-rgb1[2])/points)*i,
             ]
             for i in range(points)
         ]

--- a/src/stk/_internal/topology_graphs/cage/m2l4_lantern.py
+++ b/src/stk/_internal/topology_graphs/cage/m2l4_lantern.py
@@ -79,7 +79,7 @@ class M2L4Lantern(Cage):
 
         import moldoc.molecule as molecule
         import stk
-        
+
         four_c_bb = stk.BuildingBlock(
             smiles="[Br][C]([Br])([Br])[Br]",
             position_matrix=[
@@ -131,12 +131,12 @@ class M2L4Lantern(Cage):
             ),
         )
 
-    Metal building blocks (COLOUR1) with four functional groups are
-    required for this topology.
+    Metal building blocks (COLOUR1) with four functional groups
+    are required for this topology.
 
-    Ligand building blocks (COLOUR2) with two functional groups are required for
-    this topology.
-    
+    Ligand building blocks (COLOUR2) with two functional groups
+    are required for this topology.
+
     :class:`.MCHammer` optimization is recommended for construction.
 
     When using a :class:`dict` for the `building_blocks` parameter,

--- a/src/stk/_internal/topology_graphs/cage/m2l4_lantern.py
+++ b/src/stk/_internal/topology_graphs/cage/m2l4_lantern.py
@@ -111,7 +111,9 @@ class M2L4Lantern(Cage):
         rgb2 = [97, 201, 217]
         points = cage.get_num_atoms()
         colour_list = [
-            [(rgb1[0]-rgb2[0])*i, rgb1[1], rgb1[2]]
+            rgb1[0] + ((rgb2[0]-rgb1[0])/points)*i,
+            rgb1[1] + ((rgb2[1]-rgb1[1])/points)*i,
+            rgb1[2] + ((rgb2[2]-rgb1[2])/points)*i,
             for i in range(points)
         ]
 

--- a/src/stk/_internal/topology_graphs/cage/m2l4_lantern.py
+++ b/src/stk/_internal/topology_graphs/cage/m2l4_lantern.py
@@ -111,11 +111,7 @@ class M2L4Lantern(Cage):
         rgb2 = [97, 201, 217]
         points = cage.get_num_atoms()
         colour_list = [
-            [
-                (rgb1[0]-rgb2[0])*i,
-                (rgb1[1]-rgb2[1])*i,
-                (rgb1[2]-rgb2[2])*i,
-            ]
+            [(rgb1[0]-rgb2[0])*i, rgb1[1], rgb1[2]]
             for i in range(points)
         ]
 

--- a/src/stk/_internal/topology_graphs/cage/m2l4_lantern.py
+++ b/src/stk/_internal/topology_graphs/cage/m2l4_lantern.py
@@ -111,9 +111,11 @@ class M2L4Lantern(Cage):
         rgb2 = [97, 201, 217]
         points = cage.get_num_atoms()
         colour_list = [
-            rgb1[0] + ((rgb2[0]-rgb1[0])/points)*i,
-            rgb1[1] + ((rgb2[1]-rgb1[1])/points)*i,
-            rgb1[2] + ((rgb2[2]-rgb1[2])/points)*i,
+            [
+                rgb1[0] + ((rgb2[0]-rgb1[0])/points)*i,
+                rgb1[1] + ((rgb2[1]-rgb1[1])/points)*i,
+                rgb1[2] + ((rgb2[2]-rgb1[2])/points)*i,
+            ]
             for i in range(points)
         ]
 

--- a/src/stk/_internal/topology_graphs/cage/m2l4_lantern.py
+++ b/src/stk/_internal/topology_graphs/cage/m2l4_lantern.py
@@ -111,7 +111,11 @@ class M2L4Lantern(Cage):
         rgb2 = [97, 201, 217]
         points = cage.get_num_atoms()
         colour_list = [
-            [(rgb1[0]-rgb2[0])*i, rgb1[1], rgb1[2]]
+            [
+                (rgb1[0]-rgb2[0])*i,
+                (rgb1[1]-rgb2[1])*i,
+                (rgb1[2]-rgb2[2])*i,
+            ]
             for i in range(points)
         ]
 

--- a/src/stk/_internal/topology_graphs/cage/m2l4_lantern.py
+++ b/src/stk/_internal/topology_graphs/cage/m2l4_lantern.py
@@ -79,34 +79,32 @@ class M2L4Lantern(Cage):
 
         import moldoc.molecule as molecule
         import stk
-
-        bb1 = stk.BuildingBlock(
-            smiles='[Pd+2]',
-            functional_groups=(
-                stk.SingleAtom(stk.Pd(0, charge=2))
-                for i in range(4)
-            ),
-            position_matrix=[[0, 0, 0]],
+        
+        four_c_bb = stk.BuildingBlock(
+            smiles="[Br][C]([Br])([Br])[Br]",
+            position_matrix=[
+                [-2, 0, -1],
+                [0, 0, 1],
+                [0, -2, -1],
+                [2, 0, 1],
+                [0, 2, 1],
+            ],
+            functional_groups=(stk.BromoFactory(placers=(0, 1)),),
         )
 
-        bb2 = stk.BuildingBlock(
-            smiles=(
-                'C1=NC=CC(C2=CC=CC(C3=C'
-                'C=NC=C3)=C2)=C1'
-            ),
-            functional_groups=[
-                stk.SmartsFunctionalGroupFactory(
-                    smarts='[#6]~[#7X2]~[#6]',
-                    bonders=(1, ),
-                    deleters=(),
-                ),
+        two_c_bb = stk.BuildingBlock(
+            smiles="[Br][N][Br]",
+            position_matrix=[
+                [-2, 0, -1],
+                [0, 0, 1],
+                [0, -2, -1],
             ],
+            functional_groups=(stk.BromoFactory(placers=(0, 1)),),
         )
 
         cage = stk.ConstructedMolecule(
             topology_graph=stk.cage.M2L4Lantern(
-                building_blocks=(bb1, bb2),
-                optimizer=stk.MCHammer(),
+                building_blocks=(four_c_bb, two_c_bb),
             ),
         )
 
@@ -133,11 +131,13 @@ class M2L4Lantern(Cage):
             ),
         )
 
-    Metal building blocks with four functional groups are
+    Metal building blocks (COLOUR1) with four functional groups are
     required for this topology.
 
-    Ligand building blocks with two functional groups are required for
+    Ligand building blocks (COLOUR2) with two functional groups are required for
     this topology.
+    
+    :class:`.MCHammer` optimization is recommended for construction.
 
     When using a :class:`dict` for the `building_blocks` parameter,
     as in :ref:`cage-topology-graph-examples`:
@@ -145,8 +145,8 @@ class M2L4Lantern(Cage):
     :class:`.BuildingBlock`, with the following number of functional
     groups, needs to be assigned to each of the following vertex ids:
 
-        | 4-functional groups: 0 to 1
-        | 2-functional groups: 2 to 5
+        | 4-functional groups (COLOUR1): 0 to 1
+        | 2-functional groups (COLOUR2): 2 to 5
 
     See :class:`.Cage` for more details and examples.
 

--- a/src/stk/_internal/topology_graphs/cage/m2l4_lantern.py
+++ b/src/stk/_internal/topology_graphs/cage/m2l4_lantern.py
@@ -107,15 +107,31 @@ class M2L4Lantern(Cage):
                 building_blocks=(four_c_bb, two_c_bb),
             ),
         )
+        rgb1 = [192, 87, 161]
+        rgb2 = [97, 201, 217]
+        points = cage.get_num_atoms()
+        colour_list = [
+            [(rgb1[0]-rgb2[0])*i, rgb1[1], rgb1[2]]
+            for i in range(points)
+        ]
 
         moldoc_display_molecule = molecule.Molecule(
             atoms=(
                 molecule.Atom(
                     atomic_number=atom.get_atomic_number(),
                     position=position,
-                ) for atom, position in zip(
+                    config=molecule.AtomConfig(
+                        color=molecule.Color(
+                            red=col[0],
+                            green=col[1],
+                            blue=col[2],
+                        ),
+                        size=2.0,
+                    )
+                ) for atom, position, col in zip(
                     cage.get_atoms(),
                     cage.get_position_matrix(),
+                    colour_list,
                 )
             ),
             bonds=(

--- a/src/stk/_internal/topology_graphs/cage/m2l4_lantern.py
+++ b/src/stk/_internal/topology_graphs/cage/m2l4_lantern.py
@@ -112,9 +112,9 @@ class M2L4Lantern(Cage):
         points = cage.get_num_atoms()
         colour_list = [
             [
-                rgb1[0] + ((rgb2[0]-rgb1[0])/points)*i,
-                rgb1[1] + ((rgb2[1]-rgb1[1])/points)*i,
-                rgb1[2] + ((rgb2[2]-rgb1[2])/points)*i,
+                int(rgb1[0] + ((rgb2[0]-rgb1[0])/points)*i),
+                int(rgb1[1] + ((rgb2[1]-rgb1[1])/points)*i),
+                int(rgb1[2] + ((rgb2[2]-rgb1[2])/points)*i),
             ]
             for i in range(points)
         ]


### PR DESCRIPTION
Related Issues: #431 
Requested Reviewers: @lukasturcani 

This PR aims to improve the representation of topology graphs by removing artificial chemistry and focussing on the assignment and connectivity of vertices. Hopefully this improves website load times and accessibility to users. All changes are made in the doc strings, and small changes to readability are also attempted for all topology graphs.

- [ ] Add UNICODE colour maps between vertices and text.
- [ ] Finish cages
- [ ] Do for COFs
- [ ] Do for examples of macrocycles, host_guests, complexes and polymers.
