### PR TITLE
Add a mongo command

### DIFF
--- a/justfile
+++ b/justfile
@@ -50,3 +50,7 @@ enter-docker:
   docker run -it --rm \
     --mount type=bind,source="$(pwd)",target=/code \
     stk-test-environment:latest /bin/sh
+
+# Start a MongoDB instance in docker.
+mongo:
+  docker run -d --rm -p 27017:27017 --name mongo -d mongo:latest

--- a/justfile
+++ b/justfile
@@ -53,4 +53,4 @@ enter-docker:
 
 # Start a MongoDB instance in docker.
 mongo:
-  docker run -d --rm -p 27017:27017 --name mongo -d mongo:latest
+  docker run -d --rm -p 27017:27017 --name mongo mongo:latest


### PR DESCRIPTION
Makes it easier to start a MongoDB instance (which is
necessary for running all the tests). Running Mongo in
docker avoids the pain associated with setting up a local
Mongo server.