### PR TITLE
Remove unnecessary pip install

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -43,11 +43,6 @@ on GitHub, and you can update your ``stk`` with::
 
     $ pip install stk --upgrade
 
-``stk`` requires Python 3.11, if you are using an older version
-of Python you can use an older version of ``stk``::
-
-  $ pip install stk==2022.6.17.0
-
 How To Cite
 ===========
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -88,11 +88,6 @@ To get :mod:`.stk`, you can install it with pip::
 
   $ pip install stk
 
-:mod:`.stk` requires Python 3.11, if you are using an older
-version of Python you can use an older version of :mod:`.stk`::
-
-  $ pip install stk==2022.6.17.0
-
 Overview
 --------
 


### PR DESCRIPTION
If the user is in an old environment, the old version of stk will get 
installed anyway.