### PR TITLE
Fix complex

### DIFF
--- a/justfile
+++ b/justfile
@@ -19,7 +19,7 @@ check:
   trap error=1 ERR
 
   echo
-  (set -x; ruff . )
+  (set -x; ruff check . )
 
   echo
   ( set -x; ruff format --check . )
@@ -38,7 +38,7 @@ check:
 # Auto-fix code issues.
 fix:
   ruff format .
-  ruff --fix .
+  ruff check --fix .
 
 # Start a MongoDB instance in docker.
 mongo:

--- a/src/stk/_internal/constructed_molecule.py
+++ b/src/stk/_internal/constructed_molecule.py
@@ -366,10 +366,10 @@ class ConstructedMolecule(Molecule):
 
             canonical_building_block = building_blocks[old_building_block]
 
-            (
-                canonical_building_block_atom,
-            ) = canonical_building_block.get_atoms(
-                atom_ids=canonical_building_block_atom_id,
+            (canonical_building_block_atom,) = (
+                canonical_building_block.get_atoms(
+                    atom_ids=canonical_building_block_atom_id,
+                )
             )
 
             return AtomInfo(

--- a/src/stk/_internal/construction_state/molecule_state/molecule_state.py
+++ b/src/stk/_internal/construction_state/molecule_state/molecule_state.py
@@ -100,9 +100,9 @@ class MoleculeState:
             edge_id,
             functional_groups,
         ) in summary.get_edge_functional_groups():
-            self._edge_functional_groups[
-                edge_id
-            ] = self._edge_functional_groups.get(edge_id, [])
+            self._edge_functional_groups[edge_id] = (
+                self._edge_functional_groups.get(edge_id, [])
+            )
             self._edge_functional_groups[edge_id].extend(functional_groups)
         return self
 

--- a/src/stk/_internal/topology_graphs/cage/cage.py
+++ b/src/stk/_internal/topology_graphs/cage/cage.py
@@ -1378,9 +1378,9 @@ class Cage(TopologyGraph):
         for vertex in cls._vertex_prototypes:
             vertex_degree = cls._vertex_degrees[vertex.get_id()]
             building_block = building_blocks_by_degree[vertex_degree]
-            building_block_vertices[
-                building_block
-            ] = building_block_vertices.get(building_block, [])
+            building_block_vertices[building_block] = (
+                building_block_vertices.get(building_block, [])
+            )
             building_block_vertices[building_block].append(vertex)
         return typing.cast(
             dict[BuildingBlock, abc.Sequence[_CageVertex]],

--- a/src/stk/_internal/topology_graphs/cage/cage_construction_state.py
+++ b/src/stk/_internal/topology_graphs/cage/cage_construction_state.py
@@ -179,9 +179,9 @@ class _CageConstructionState(ConstructionState):
                 (functional_group,) = building_block.get_functional_groups(
                     fg_id
                 )
-                self._neighbor_positions[
-                    neighbor_id
-                ] = self._neighbor_positions.get(neighbor_id, [])
+                self._neighbor_positions[neighbor_id] = (
+                    self._neighbor_positions.get(neighbor_id, [])
+                )
                 self._neighbor_positions[neighbor_id].append(
                     building_block.get_centroid(
                         atom_ids=functional_group.get_placer_ids(),

--- a/src/stk/_internal/topology_graphs/cof/cof.py
+++ b/src/stk/_internal/topology_graphs/cof/cof.py
@@ -780,9 +780,9 @@ class Cof(TopologyGraph):
         for vertex in vertices:
             vertex_degree = vertex_degrees[vertex.get_id()]
             building_block = building_blocks_by_degree[vertex_degree]
-            building_block_vertices[
-                building_block
-            ] = building_block_vertices.get(building_block, [])
+            building_block_vertices[building_block] = (
+                building_block_vertices.get(building_block, [])
+            )
             building_block_vertices[building_block].append(vertex)
         return building_block_vertices
 

--- a/src/stk/_internal/topology_graphs/host_guest/complex.py
+++ b/src/stk/_internal/topology_graphs/host_guest/complex.py
@@ -500,20 +500,27 @@ class Complex(TopologyGraph):
             guests = (guests,)
 
         building_block_vertices: dict[BuildingBlock, abc.Sequence[Vertex]]
-        building_block_vertices = {host: (HostVertex(0, (0.0, 0.0, 0.0)),)}
-        guest_vertices = {
-            guest.get_building_block(): (
-                GuestVertex(
-                    id=i + 1,
-                    position=guest.get_displacement(),
-                    start=guest.get_start_vector(),
-                    target=guest.get_end_vector(),
-                ),
-            )
-            for i, guest in enumerate(guests)
-        }
-        building_block_vertices.update(guest_vertices)
-
+        building_block_vertices = {host: [HostVertex(0, (0.0, 0.0, 0.0))]}
+        for id_, guest in enumerate(guests, 1):
+            building_block = guest.get_building_block()
+            if building_block in building_block_vertices:
+                building_block_vertices[building_block].append(
+                    GuestVertex(
+                        id=id_,
+                        position=guest.get_displacement(),
+                        start=guest.get_start_vector(),
+                        target=guest.get_end_vector(),
+                    ),
+                )
+            else:
+                building_block_vertices[building_block] = [
+                    GuestVertex(
+                        id=id_,
+                        position=guest.get_displacement(),
+                        start=guest.get_start_vector(),
+                        target=guest.get_end_vector(),
+                    ),
+                ]
         return building_block_vertices
 
     def clone(self) -> Complex:

--- a/src/stk/_internal/topology_graphs/host_guest/complex.py
+++ b/src/stk/_internal/topology_graphs/host_guest/complex.py
@@ -499,7 +499,7 @@ class Complex(TopologyGraph):
         if isinstance(guests, Guest):
             guests = (guests,)
 
-        building_block_vertices: dict[BuildingBlock, abc.Sequence[Vertex]]
+        building_block_vertices: dict[BuildingBlock, list[Vertex]]
         building_block_vertices = {host: [HostVertex(0, (0.0, 0.0, 0.0))]}
         for id_, guest in enumerate(guests, 1):
             building_block = guest.get_building_block()
@@ -521,7 +521,7 @@ class Complex(TopologyGraph):
                         target=guest.get_end_vector(),
                     ),
                 ]
-        return building_block_vertices
+        return building_block_vertices  # type: ignore
 
     def clone(self) -> Complex:
         return self._clone()


### PR DESCRIPTION
Related Issues: #524

The existing implementation was overwriting the existing host
vertex if the guest was the same building block as the vertex.
Fix this by appending to the list of vertices that a given building
block is attached to.

